### PR TITLE
Add `Source-Dir` Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,17 @@ jobs:
 
       - name: Run build result
         run: ./build/hello_world
+
+  use-action-with-specified-source-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Use this action with specified source directory
+        uses: ./
+        with:
+          source-dir: test
+
+      - name: Run build result
+        run: ./build/hello_world

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # CMake Action
 
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/cmake-action/test.yml?label=test&branch=main)](https://github.com/threeal/cmake-action/actions/workflows/test.yml)
+
 Configure and build [CMake](https://cmake.org/) project on [GitHub Actions](https://github.com/features/actions).

--- a/action.yml
+++ b/action.yml
@@ -4,12 +4,23 @@ author: Alfi Maulana
 branding:
   color: gray-dark
   icon: terminal
+inputs:
+  source-dir:
+    description: The source directory of CMake project
+    required: false
+    default: .
 runs:
   using: composite
   steps:
+    - name: Process inputs
+      shell: bash
+      run: |
+        CONFIGURE_ARGS="'${{ inputs.source-dir }}' -B build"
+        echo "CMAKE_CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
+
     - name: Configure CMake
       shell: bash
-      run: cmake . -B build
+      run: cmake ${{ env.CMAKE_CONFIGURE_ARGS }}
 
     - name: Build targets
       shell: bash


### PR DESCRIPTION
Closes #2.

- Add `source-dir` input to specify which source directory to be used.
- Add workflow step to test this Action if using specified source directory.
- Add test status badge in the `README.md`.
