### PR TITLE
Add `build-dir` Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,18 @@ jobs:
 
       - name: Run build result
         run: ./build/hello_world
+
+  use-action-with-specified-build-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Use this action with specified build directory
+        uses: ./
+        with:
+          source-dir: test
+          build-dir: test/build
+
+      - name: Run build result
+        run: test/build/hello_world

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Run build result
         run: test/build/hello_world
+
+      - name: Check if default build directory is not exist
+        run: test ! -d build

--- a/action.yml
+++ b/action.yml
@@ -9,14 +9,20 @@ inputs:
     description: The source directory of CMake project
     required: false
     default: .
+  build-dir:
+    description: The build directory of CMake project
+    required: false
+    default: build
 runs:
   using: composite
   steps:
     - name: Process inputs
       shell: bash
       run: |
-        CONFIGURE_ARGS="'${{ inputs.source-dir }}' -B build"
+        CONFIGURE_ARGS="'${{ inputs.source-dir }}' -B '${{ inputs.build-dir }}'"
+        BUILD_ARGS="--build '${{ inputs.build-dir }}'"
         echo "CMAKE_CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
+        echo "CMAKE_BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV
 
     - name: Configure CMake
       shell: bash
@@ -24,4 +30,4 @@ runs:
 
     - name: Build targets
       shell: bash
-      run: cmake --build build
+      run: cmake ${{ env.CMAKE_BUILD_ARGS }}


### PR DESCRIPTION
Closes #3.

- Add `build-dir` input option for specifying which build directory to be used by CMake.
- Add workflow job to test this action if build directory is specified.