### PR TITLE
Add Compiler Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,22 @@ jobs:
       - name: Check if default build directory is not exist
         run: test ! -d build
 
+  use-action-with-specified-compiler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Use this action with specified compiler
+        uses: ./
+        with:
+          source-dir: test
+          c-compiler: clang
+          cxx-compiler: clang++
+
+      - name: Run build result
+        run: build/hello_world
+
   use-action-with-additional-args:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
 
+      - name: Use this action with specified invalid compiler
+        id: failed_step
+        continue-on-error: true
+        uses: ./
+        with:
+          source-dir: test
+          c-compiler: ${{ matrix.lang == 'C' && 'invalid' || '' }}
+          cxx-compiler: ${{ matrix.lang == 'CXX' && 'invalid' || '' }}
+
+      - name: Check if previous step is failing
+        run: ${{ steps.failed_step.outcome == 'failure' && 'true' || 'false' }}
+
       - name: Use this action with specified compiler
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
 
   use-action-with-specified-compiler:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lang: [C, CXX]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
@@ -63,11 +66,14 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          c-compiler: clang
-          cxx-compiler: clang++
+          c-compiler: ${{ matrix.lang == 'C' && 'clang' || '' }}
+          cxx-compiler: ${{ matrix.lang == 'CXX' && 'clang++' || '' }}
+          args: |
+            -D BUILD_C=${{ matrix.lang == 'C' && 'ON' || 'OFF' }}
+            -D BUILD_CXX=${{ matrix.lang == 'CXX' && 'ON' || 'OFF' }}
 
       - name: Run build result
-        run: build/hello_world
+        run: build/${{ matrix.lang == 'C' && 'hello_world_c' || 'hello_world' }}
 
   use-action-with-additional-args:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: The build directory of CMake project
     required: false
     default: build
+  c-compiler:
+    description: Preferred executable for compiling C language files
+    required: false
 runs:
   using: composite
   steps:
@@ -21,6 +24,9 @@ runs:
       run: |
         CONFIGURE_ARGS="${{ inputs.source-dir }} -B ${{ inputs.build-dir }}"
         BUILD_ARGS="--build ${{ inputs.build-dir }}"
+        if [ -n '${{ inputs.c-compiler }}' ]; then
+          CONFIGURE_ARGS="$CONFIGURE_ARGS -D CMAKE_C_COMPILER=${{ inputs.c-compiler }}"
+        fi
         echo "CMAKE_CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
         echo "CMAKE_BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV
 

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,8 @@ runs:
         if [ -n '${{ inputs.args }}' ]; then
           CONFIGURE_ARGS="$CONFIGURE_ARGS ${{ inputs.args }}"
         fi
-        echo "CMAKE_CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
-        echo "CMAKE_BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV
+        echo "CMAKE_CONFIGURE_ARGS=${CONFIGURE_ARGS//[$'\t\r\n']}" >> $GITHUB_ENV
+        echo "CMAKE_BUILD_ARGS=${BUILD_ARGS//[$'\t\r\n']}" >> $GITHUB_ENV
 
     - name: Configure CMake
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   c-compiler:
     description: The preferred executable for compiling C language files
     required: false
+  cxx-compiler:
+    description: The preferred executable for compiling CXX language files
+    required: false
   args:
     description: Additional arguments passed during CMake configuration
     required: false
@@ -29,6 +32,9 @@ runs:
         BUILD_ARGS="--build ${{ inputs.build-dir }}"
         if [ -n '${{ inputs.c-compiler }}' ]; then
           CONFIGURE_ARGS="$CONFIGURE_ARGS -D CMAKE_C_COMPILER=${{ inputs.c-compiler }}"
+        fi
+        if [ -n '${{ inputs.cxx-compiler }}' ]; then
+          CONFIGURE_ARGS="$CONFIGURE_ARGS -D CMAKE_CXX_COMPILER=${{ inputs.cxx-compiler }}"
         fi
         if [ -n '${{ inputs.args }}' ]; then
           CONFIGURE_ARGS="$CONFIGURE_ARGS ${{ inputs.args }}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,17 @@
 cmake_minimum_required(VERSION 3.0)
 project(test)
 
+option(BUILD_C "build hello world in C Language" OFF)
+option(BUILD_CXX "build hello world in CXX Language" ON)
 option(BUILD_TXT "build hello world txt file" OFF)
 
-add_executable(hello_world hello_world.cpp)
+if(BUILD_C)
+  add_executable(hello_world_c hello_world.c)
+endif()
+
+if(BUILD_CXX)
+  add_executable(hello_world hello_world.cpp)
+endif()
 
 if(BUILD_TXT)
   add_custom_target(

--- a/test/hello_world.c
+++ b/test/hello_world.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello world!\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #7.

- Add `c-compiler` and `cxx-compiler` input options.
- Fix input if it contains multi line values.
- Add workflow job to test those inputs by:
  - Add support to compile `hello_world` from C language.
  - Add CMake option to chose between C and/or CXX to compile the `hello_world`.