### PR TITLE
Add Other Arguments Input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,21 @@ jobs:
 
       - name: Check if default build directory is not exist
         run: test ! -d build
+
+  use-action-with-other-args:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Use this action with build txt enabled
+        uses: ./
+        with:
+          source-dir: test
+          args: -D BUILD_TXT=ON
+
+      - name: Run build result
+        run: build/hello_world
+
+      - name: Check if the txt result exist
+        run: cat build/hello_world.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check if default build directory is not exist
         run: test ! -d build
 
-  use-action-with-other-args:
+  use-action-with-additional-args:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: build
   args:
-    description: Other arguments passed during CMake configuration
+    description: Additional arguments passed during CMake configuration
     required: false
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
         CONFIGURE_ARGS="${{ inputs.source-dir }} -B ${{ inputs.build-dir }}"
         BUILD_ARGS="--build ${{ inputs.build-dir }}"
         if [ -n '${{ inputs.args }}' ]; then
-          CMAKE_CONFIGURE_ARGS="$CMAKE_CONFIGURE_ARGS ${{ inputs.args }}"
+          CONFIGURE_ARGS="$CONFIGURE_ARGS ${{ inputs.args }}"
         fi
         echo "CMAKE_CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
         echo "CMAKE_BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: The build directory of CMake project
     required: false
     default: build
+  args:
+    description: Other arguments passed during CMake configuration
+    required: false
 runs:
   using: composite
   steps:
@@ -21,6 +24,9 @@ runs:
       run: |
         CONFIGURE_ARGS="${{ inputs.source-dir }} -B ${{ inputs.build-dir }}"
         BUILD_ARGS="--build ${{ inputs.build-dir }}"
+        if [ -n '${{ inputs.args }}' ]; then
+          CMAKE_CONFIGURE_ARGS="$CMAKE_CONFIGURE_ARGS ${{ inputs.args }}"
+        fi
         echo "CMAKE_CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
         echo "CMAKE_BUILD_ARGS=$BUILD_ARGS" >> $GITHUB_ENV
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,13 @@
 cmake_minimum_required(VERSION 3.0)
 project(test)
+
+option(BUILD_TXT "build hello world txt file" OFF)
+
 add_executable(hello_world hello_world.cpp)
+
+if(BUILD_TXT)
+  add_custom_target(
+    hello_world_txt ALL
+    COMMAND echo "Hello world!" >> ${CMAKE_CURRENT_BINARY_DIR}/hello_world.txt
+  )
+endif()


### PR DESCRIPTION
- Add `args` input option to specify additional arguments passed during CMake configuration.
- Add option to build `hello_world.txt` in CMake by enabling `BUILD_TXT`.
- Add a workflow job to test the `args` input option by checking if `BUILD_TXT` could be enabled using that input.