### PR TITLE
Add Generator Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,21 @@ jobs:
 
       - name: Run build result
         run: build/${{ matrix.lang == 'C' && 'hello_world_c' || 'hello_world' }}
+
+  use-action-with-specified-generator:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Install Ninja
+        run: sudo apt install -y ninja-build
+
+      - name: Use this action with specified generator
+        uses: ./
+        with:
+          source-dir: test
+          generator: Ninja
+
+      - name: Run build result
+        run: build/hello_world

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: The build directory of CMake project
     required: false
     default: build
+  generator:
+    description: The build system generator of the CMake project
+    required: false
   c-compiler:
     description: The preferred executable for compiling C language files
     required: false
@@ -30,6 +33,9 @@ runs:
       run: |
         CONFIGURE_ARGS="${{ inputs.source-dir }} -B ${{ inputs.build-dir }}"
         BUILD_ARGS="--build ${{ inputs.build-dir }}"
+        if [ -n '${{ inputs.generator }}' ]; then
+          CONFIGURE_ARGS="$CONFIGURE_ARGS -G ${{ inputs.generator }}"
+        fi
         if [ -n '${{ inputs.c-compiler }}' ]; then
           CONFIGURE_ARGS="$CONFIGURE_ARGS -D CMAKE_C_COMPILER=${{ inputs.c-compiler }}"
         fi


### PR DESCRIPTION
Closes #10.

Add `generator` input option and add a workflow job to test that input.