### PR TITLE
Add Targets Input Option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,10 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          targets: test
+          targets: test_c test_cpp
 
       - name: Run build result
-        run: build/test
+        run: build/test_c && build/test_cpp
 
   use-action-with-specified-compiler:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,21 @@ jobs:
       - name: Check if the default build directory does not exist
         run: test ! -d build
 
+  use-action-with-specified-targets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Use this action with specified targets
+        uses: ./
+        with:
+          source-dir: test
+          targets: test
+
+      - name: Run build result
+        run: build/test
+
   use-action-with-specified-compiler:
     runs-on: ubuntu-latest
     strategy:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: The build directory of CMake project
     required: false
     default: build
+  targets:
+    description: List of build targets
+    required: false
   generator:
     description: The build system generator of the CMake project
     required: false
@@ -33,6 +36,9 @@ runs:
       run: |
         ARGS="${{ inputs.source-dir }} -B ${{ inputs.build-dir }}"
         BUILD_ARGS="--build ${{ inputs.build-dir }}"
+        if [ -n '${{ inputs.targets }}' ]; then
+          BUILD_ARGS="$BUILD_ARGS --target ${{ inputs.targets }}"
+        fi
         if [ -n '${{ inputs.generator }}' ]; then
           ARGS="$ARGS -G ${{ inputs.generator }}"
         fi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,4 +12,5 @@ if(BUILD_CXX)
   add_executable(hello_world hello_world.cpp)
 endif()
 
-add_executable(test EXCLUDE_FROM_ALL test.cpp)
+add_executable(test_c EXCLUDE_FROM_ALL test.c)
+add_executable(test_cpp EXCLUDE_FROM_ALL test.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,3 +11,5 @@ endif()
 if(BUILD_CXX)
   add_executable(hello_world hello_world.cpp)
 endif()
+
+add_executable(test EXCLUDE_FROM_ALL test.cpp)

--- a/test/test.c
+++ b/test/test.c
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/test/test.c
+++ b/test/test.c
@@ -1,3 +1,6 @@
+#include <stdio.h>
+
 int main() {
+  printf("all ok\n");
   return 0;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,6 @@
+#include <iostream>
+
 int main() {
+  std::cout << "all ok" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Closes #17.

- Add `targets` input option to specify list of build targets.
- Add `test_c` and `test_cpp` targets in the test project for testing the `targets` input option.