### PR TITLE
Add Compiler Flags Input Options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,23 @@ jobs:
       - name: Check if the default build directory does not exist
         run: test ! -d build
 
+  additional-flags-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out this repository
+        uses: actions/checkout@v3.3.0
+
+      - name: Use this action with additional compiler flags
+        uses: ./
+        with:
+          source-dir: test
+          targets: test_c test_cpp
+          c-flags: -Wno-unused-variable
+          cxx-flags: -Wno-unused-variable
+
+      - name: Run the build results
+        run: build/test_c && build/test_cpp
+
   specified-compiler-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ For more information, see [action.yml](./action.yml) and [GitHub Actions guide](
 | `generator` | String | Build system generator of the CMake project. |
 | `c-compiler` | String | Preferred executable for compiling C language files. |
 | `cxx-compiler` | String | Preferred executable for compiling CXX language files. |
+| `c-flags` | Multiple strings | Additional flags passed when compiling C language files. Could be specified more than one. Separate each flag with a space or a new line. |
+| `cxx-flags` | Multiple strings | Additional flags passed when compiling C++ language files. Could be specified more than one. Separate each flag with a space or a new line. |
 | `args` | Multiple strings | Additional arguments passed during the CMake configuration. Could be specified more than one. Separate each target with a space or a new line. |
 
 ### Examples

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,12 @@ inputs:
   cxx-compiler:
     description: Preferred executable for compiling CXX language files
     required: false
+  c-flags:
+    description: Additional flags passed when compiling C language files
+    required: false
+  cxx-flags:
+    description: Additional flags passed when compiling C++ language files
+    required: false
   args:
     description: Additional arguments passed during the CMake configuration
     required: false
@@ -48,6 +54,12 @@ runs:
         fi
         if [ -n '${{ inputs.cxx-compiler }}' ]; then
           ARGS="$ARGS -D CMAKE_CXX_COMPILER=${{ inputs.cxx-compiler }}"
+        fi
+        if [ -n '${{ inputs.c-flags }}' ]; then
+          ARGS="$ARGS -D CMAKE_C_FLAGS=${{ inputs.c-flags }}"
+        fi
+        if [ -n '${{ inputs.cxx-flags }}' ]; then
+          ARGS="$ARGS -D CMAKE_CXX_FLAGS=${{ inputs.cxx-flags }}"
         fi
         if [ -n '${{ inputs.args }}' ]; then
           ARGS="$ARGS ${{ inputs.args }}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.0)
 project(test)
 
 option(CHECK_USING_CLANG "check if target is compiled using Clang" OFF)
+option(CHECK_SURPASS_WARNING "check if target could surpass a compiler warning" OFF)
+
+set(CMAKE_C_FLAGS "-Werror -Wunused-variable ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Werror -Wunused-variable ${CMAKE_CXX_FLAGS}")
 
 add_executable(hello_world hello_world.cpp)
 
@@ -13,5 +17,6 @@ foreach(LANG ${LANGS})
     test_${LANG} PRIVATE
     $<$<STREQUAL:"${LANG}","c">:IS_C>
     $<$<BOOL:${CHECK_USING_CLANG}>:CHECK_USING_CLANG>
+    $<$<BOOL:${CHECK_SURPASS_WARNING}>:CHECK_SURPASS_WARNING>
   )
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,10 @@ project(test)
 option(CHECK_USING_CLANG "check if target is compiled using Clang" OFF)
 option(CHECK_SURPASS_WARNING "check if target could surpass a compiler warning" OFF)
 
-set(CMAKE_C_FLAGS "-Werror -Wunused-variable ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-Werror -Wunused-variable ${CMAKE_CXX_FLAGS}")
+if(CHECK_SURPASS_WARNING)
+  set(CMAKE_C_FLAGS "-Werror -Wunused-variable ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-Werror -Wunused-variable ${CMAKE_CXX_FLAGS}")
+endif()
 
 add_executable(hello_world hello_world.cpp)
 

--- a/test/test.in
+++ b/test/test.in
@@ -7,6 +7,9 @@
 #endif
 
 int main() {
+#ifdef CHECK_SURPASS_WARNING
+  int unused;
+#endif
 #if defined(CHECK_USING_CLANG) && !defined(__clang__)
   PRINT("compiler is not clang");
   return 1;


### PR DESCRIPTION
Closes #23.

- Add action inputs for specifying compiler flags to be used:
  - `c-flags` for C compiler.
  - `cxx-flags` for C++ compiler.
- Add option in test project for checking if this action could surpass warning by passing a compiler flag.
- Add a job in `test.yml` to test compiler flags input by passing a compiler flag to surpass a warning.