### PR TITLE
Modify Dependabot Commit Message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
Add a `chore` prefix in the [Dependabot](https://github.com/dependabot) commit message.