### PR TITLE
Default to No Build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,11 +56,11 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          targets: test_c test_cpp
           c-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           cxx-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           args: -D CHECK_SURPASS_WARNING=ON
           run-build: true
+          build-args: --target test_c --target test_cpp
           run-test: true
           test-args: -R test ${{ matrix.compiler == 'msvc' && '-C Debug' || '' }}
 
@@ -77,12 +77,12 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          targets: test_c test_cpp
           generator: Ninja
           c-compiler: clang
           cxx-compiler: clang++
           args: -D CHECK_USING_CLANG=ON
           run-build: true
+          build-args: --target test_c --target test_cpp
           run-test: true
           test-args: -R test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,37 +11,77 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Check out this repository
+      - name: Checkout the repository
         uses: actions/checkout@v3.5.3
 
-      - name: Move test project to the working directory
+      - name: Move the test project to the working directory
         run: mv test/* .
 
-      - name: Use this action
+      - name: Use the action
         uses: ./
-        with:
-          run-build: true
 
-      - name: Run the build result
-        run: ${{ matrix.os == 'windows' && 'build\Debug\hello_world.exe' || 'build/hello_world' }}
+      - name: Try to test the project
+        id: failed-step
+        continue-on-error: true
+        run: ctest --test-dir build --output-on-failure --no-tests=error
+
+      - name: Check on success
+        if: steps.failed-step.outcome == 'success'
+        run: exit 1
+
+      - name: Build and test the project
+        run: |
+          cmake --build build
+          ctest --test-dir build --output-on-failure --no-tests=error
 
   specified-dir-usage:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out this repository
+      - name: Checkout the repository
         uses: actions/checkout@v3.5.3
 
-      - name: Use this action with specified directories
+      - name: Use the action with specified directories
         uses: ./
         with:
           source-dir: test
           build-dir: output
-          run-build: true
-          run-test: true
-          test-args: -R hello_world
 
       - name: Check if the default build directory does not exist
-        run: test ! -d build && test ! -d test/build
+        shell: bash
+        run: test ! -e build && test ! -e test/build
+
+      - name: Build and test the project
+        run: |
+          cmake --build output
+          ctest --test-dir output --output-on-failure --no-tests=error
+
+  run-build-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3.5.3
+
+      - name: Use the action with run build enabled
+        uses: ./
+        with:
+          source-dir: test
+          run-build: true
+
+      - name: Test the project
+        run: ctest --test-dir build --output-on-failure --no-tests=error
+
+  run-test-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3.5.3
+
+      - name: Use the action with run test enabled
+        uses: ./
+        with:
+          source-dir: test
+          run-build: true
+          run-test: true
 
   additional-flags-usage:
     runs-on: ${{ matrix.compiler == 'msvc' && 'windows' || 'ubuntu' }}-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          run-build: true
           run-test: true
           test-args: -R hello_world
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Try to test the project
         id: failed-step
         continue-on-error: true
-        run: ctest --test-dir build --output-on-failure --no-tests=error -R hello_world
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R hello_world ${{ matrix.os == 'windows' && '-C Debug' || '' }}
 
       - name: Check on success
         if: steps.failed-step.outcome == 'success'
@@ -33,7 +33,7 @@ jobs:
       - name: Build and test the project
         run: |
           cmake --build build
-          ctest --test-dir build --output-on-failure --no-tests=error -R hello_world
+          ctest --test-dir build --output-on-failure --no-tests=error -R hello_world ${{ matrix.os == 'windows' && '-C Debug' || '' }}
 
   specified-dir-usage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           run-test: true
           test-args: -R test ${{ matrix.compiler == 'msvc' && '-C Debug' || '' }}
 
-  specified-compiler-usage:
+  specified-generator-and-compiler-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
       - name: Check out this repository
         uses: actions/checkout@v3.5.3
 
-      - name: Use this action with specified compilers
+      - name: Use this action with specified generator and compilers
         uses: ./
         with:
           source-dir: test
@@ -130,22 +130,3 @@ jobs:
           build-args: --target test_c --target test_cpp
           run-test: true
           test-args: -R test
-
-  specified-generator-usage:
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
-    steps:
-      - name: Check out this repository
-        uses: actions/checkout@v3.5.3
-
-      - name: Use this action with a specified generator
-        uses: ./
-        with:
-          source-dir: test
-          generator: Ninja
-          run-build: true
-          run-test: true
-          test-args: -R hello_world

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Try to test the project
         id: failed-step
         continue-on-error: true
-        run: ctest --test-dir build --output-on-failure --no-tests=error
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R hello_world
 
       - name: Check on success
         if: steps.failed-step.outcome == 'success'
@@ -33,7 +33,7 @@ jobs:
       - name: Build and test the project
         run: |
           cmake --build build
-          ctest --test-dir build --output-on-failure --no-tests=error
+          ctest --test-dir build --output-on-failure --no-tests=error -R hello_world
 
   specified-dir-usage:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
       - name: Build and test the project
         run: |
           cmake --build output
-          ctest --test-dir output --output-on-failure --no-tests=error
+          ctest --test-dir output --output-on-failure --no-tests=error -R hello_world
 
   run-build-usage:
     runs-on: ubuntu-latest
@@ -67,9 +67,10 @@ jobs:
         with:
           source-dir: test
           run-build: true
+          build-args: --target test_c --target test_cpp
 
       - name: Test the project
-        run: ctest --test-dir build --output-on-failure --no-tests=error
+        run: ctest --test-dir test/build --output-on-failure --no-tests=error -R test
 
   run-test-usage:
     runs-on: ubuntu-latest
@@ -83,6 +84,7 @@ jobs:
           source-dir: test
           run-build: true
           run-test: true
+          test-args: -R hello_world
 
   additional-flags-usage:
     runs-on: ${{ matrix.compiler == 'msvc' && 'windows' || 'ubuntu' }}-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Use this action
         uses: ./
+        with:
+          run-build: true
 
       - name: Run the build result
         run: ${{ matrix.os == 'windows' && 'build\Debug\hello_world.exe' || 'build/hello_world' }}
@@ -34,6 +36,7 @@ jobs:
         with:
           source-dir: test
           build-dir: output
+          run-build: true
           run-test: true
           test-args: -R hello_world
 
@@ -54,10 +57,11 @@ jobs:
         with:
           source-dir: test
           targets: test_c test_cpp
-          run-test: true
           c-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           cxx-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           args: -D CHECK_SURPASS_WARNING=ON
+          run-build: true
+          run-test: true
           test-args: -R test ${{ matrix.compiler == 'msvc' && '-C Debug' || '' }}
 
   specified-compiler-usage:
@@ -74,11 +78,12 @@ jobs:
         with:
           source-dir: test
           targets: test_c test_cpp
-          run-test: true
           generator: Ninja
           c-compiler: clang
           cxx-compiler: clang++
           args: -D CHECK_USING_CLANG=ON
+          run-build: true
+          run-test: true
           test-args: -R test
 
   specified-generator-usage:
@@ -94,6 +99,7 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          run-test: true
           generator: Ninja
+          run-build: true
+          run-test: true
           test-args: -R hello_world

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   default-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:
@@ -86,6 +87,7 @@ jobs:
   additional-flags-usage:
     runs-on: ${{ matrix.compiler == 'msvc' && 'windows' || 'ubuntu' }}-latest
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc, msvc]
     steps:
@@ -107,6 +109,7 @@ jobs:
   specified-compiler-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:
@@ -129,6 +132,7 @@ jobs:
   specified-generator-usage:
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,10 +92,10 @@ jobs:
       matrix:
         compiler: [gcc, msvc]
     steps:
-      - name: Check out this repository
+      - name: Checkout the repository
         uses: actions/checkout@v3.5.3
 
-      - name: Use this action with additional compiler flags
+      - name: Use the action with additional compiler flags
         uses: ./
         with:
           source-dir: test
@@ -114,10 +114,10 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Check out this repository
+      - name: Checkout the repository
         uses: actions/checkout@v3.5.3
 
-      - name: Use this action with specified generator and compilers
+      - name: Use the action with specified generator and compilers
         uses: ./
         with:
           source-dir: test

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![License](https://img.shields.io/github/license/threeal/cmake-action)](./LICENSE)
 [![Test Status](https://img.shields.io/github/actions/workflow/status/threeal/cmake-action/test.yml?label=test&branch=main)](https://github.com/threeal/cmake-action/actions/workflows/test.yml)
 
-Configure, build, and test your [CMake](https://cmake.org/) project using [GitHub Actions](https://github.com/features/actions). This action simplifies the workflow for your CMake project. It configures the build environment using the `cmake` command, builds the project using the `cmake --build` command, and optionally tests the project using the `ctest` command.
+Configure, build, and test your [CMake](https://cmake.org/) project using [GitHub Actions](https://github.com/features/actions). This action simplifies the workflow for your CMake project. It configures the build environment using the `cmake` command, and optionally builds the project using the `cmake --build` command and tests the project using the `ctest` command.
 
 ## Features
 
-- Configures and builds a project using the [cmake](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command.
+- Configures a project using the [cmake](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command.
+- Option to build a project using the `cmake --build` command.
 - Option to test a project using the [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html) command.
 - Auto-detects and installs required dependencies.
 - Supports specifying multiple CMake options directly from the Action inputs.
@@ -21,16 +22,17 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 
 | Name | Value Type | Description |
 | --- | --- | --- |
-| `source-dir` | Path | Source directory of the CMake project. Defaults to the current directory. |
-| `build-dir` | Path | Build directory of the CMake project. Defaults to the `build` directory inside the source directory. |
-| `targets` | Multiple strings | List of build targets. |
-| `generator` | String | Build system generator for the CMake project. |
-| `c-compiler` | String | Preferred executable for compiling C language files. |
-| `cxx-compiler` | String | Preferred executable for compiling C++ language files. |
+| `source-dir` | Path | The source directory of the CMake project. Defaults to the current directory. |
+| `build-dir` | Path | The source directory of the CMake project.. Defaults to the `build` directory inside the source directory. |
+| `targets` | Multiple strings | A list of build targets. |
+| `generator` | String | The build system generator for the CMake project. |
+| `c-compiler` | String | The preferred executable for compiling C language files. |
+| `cxx-compiler` | String | The preferred executable for compiling C++ language files. |
 | `c-flags` | Multiple strings | Additional flags passed when compiling C language files. |
 | `cxx-flags` | Multiple strings | Additional flags passed when compiling C++ language files. |
-| `args` | Multiple strings | Additional arguments passed during CMake configuration. |
-| `run-test` | `true` or `false` | If enabled, runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
+| `args` | Multiple strings | Additional arguments passed during the CMake configuration. |
+| `run-build` | `true` or `false` | If enabled, it builds the project using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
+| `run-test` | `true` or `false` | If enabled, it runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
 | `test-args` | Multiple strings | Additional arguments passed during the CTest run. |
 
 > Note: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.
@@ -47,10 +49,10 @@ jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out this repository
+      - name: Check out the repository
         uses: actions/checkout@v3.3.0
 
-      - name: Configure and build this project
+      - name: Configure the project
         uses: threeal/cmake-action@latest
 ```
 
@@ -59,11 +61,22 @@ jobs:
 #### Specify the Source and Build Directories
 
 ```yaml
-- name: Configure and build this project
+- name: Configure the project
   uses: threeal/cmake-action@latest
   with:
     source-dir: submodules
     build-dir: submodules/out
+```
+
+#### Configure, Build, and Test in the Same Step
+
+```yaml
+- name: Configure, build, and test the project
+  uses: threeal/cmake-action@latest
+  with:
+    args: -DBUILD_TESTING=ON
+    run-build: true
+    run-test: true
 ```
 
 #### Specify the Build Targets
@@ -72,17 +85,8 @@ jobs:
 - name: Configure and build this project
   uses: threeal/cmake-action@latest
   with:
+    run-build: true
     targets: hello_mars hello_sun
-```
-
-#### Run Unit Tests After Build
-
-```yaml
-- name: Configure, build, and test this project
-  uses: threeal/cmake-action@latest
-  with:
-    args: -DBUILD_TESTING=ON
-    run-test: true
 ```
 
 #### Using Ninja as the Generator and Clang as the Compiler

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Configure, build, and test your [CMake](https://cmake.org/) project using [GitHu
 
 ## Features
 
-- Configures a project using the [cmake](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command.
+- Configures a project using the [`cmake`](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command.
 - Option to build a project using the `cmake --build` command.
-- Option to test a project using the [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html) command.
+- Option to test a project using the [`ctest`](https://cmake.org/cmake/help/latest/manual/ctest.1.html) command.
 - Auto-detects and installs required dependencies.
 - Supports specifying multiple CMake options directly from the Action inputs.
 
@@ -22,18 +22,18 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 
 | Name | Value Type | Description |
 | --- | --- | --- |
-| `source-dir` | Path | The source directory of the CMake project. Defaults to the current directory. |
-| `build-dir` | Path | The source directory of the CMake project.. Defaults to the `build` directory inside the source directory. |
-| `targets` | Multiple strings | A list of build targets. |
+| `source-dir` | Path | The source directory of the CMake project. It defaults to the current directory. |
+| `build-dir` | Path | The build directory of the CMake project. It defaults to the `build` directory inside the source directory. |
 | `generator` | String | The build system generator for the CMake project. |
 | `c-compiler` | String | The preferred executable for compiling C language files. |
 | `cxx-compiler` | String | The preferred executable for compiling C++ language files. |
-| `c-flags` | Multiple strings | Additional flags passed when compiling C language files. |
-| `cxx-flags` | Multiple strings | Additional flags passed when compiling C++ language files. |
-| `args` | Multiple strings | Additional arguments passed during the CMake configuration. |
-| `run-build` | `true` or `false` | If enabled, it builds the project using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
-| `run-test` | `true` or `false` | If enabled, it runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
-| `test-args` | Multiple strings | Additional arguments passed during the CTest run. |
+| `c-flags` | Multiple strings | Additional flags to pass when compiling C language files. |
+| `cxx-flags` | Multiple strings | Additional flags to pass when compiling C++ language files. |
+| `args` | Multiple strings | Additional arguments to pass during the CMake configuration. |
+| `run-build` | `true` or `false` | If enabled, it builds the project using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). It defaults to `false`. |
+| `build-args` | Multiple strings | Additional arguments to pass during the CMake build. |
+| `run-test` | `true` or `false` | If enabled, it runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). It defaults to `false`. |
+| `test-args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
 > Note: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.
 
@@ -77,16 +77,6 @@ jobs:
     args: -DBUILD_TESTING=ON
     run-build: true
     run-test: true
-```
-
-#### Specify the Build Targets
-
-```yaml
-- name: Configure and build this project
-  uses: threeal/cmake-action@latest
-  with:
-    run-build: true
-    targets: hello_mars hello_sun
 ```
 
 #### Using Ninja as the Generator and Clang as the Compiler

--- a/README.md
+++ b/README.md
@@ -49,11 +49,17 @@ jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
+      - name: Checkout the repository
         uses: actions/checkout@v3.3.0
 
       - name: Configure the project
         uses: threeal/cmake-action@latest
+
+      - name: Build the project
+        runs: cmake --build build
+
+      - name: Test the project
+        runs: ctest --test-dir build
 ```
 
 > Note: You can replace `@latest` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
@@ -82,7 +88,7 @@ jobs:
 #### Using Ninja as the Generator and Clang as the Compiler
 
 ```yaml
-- name: Configure and build this project
+- name: Configure and build the project
   uses: threeal/cmake-action@latest
   with:
     generator: Ninja

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 | `source-dir` | Path | Source directory of the CMake project. Defaults to the current directory. |
 | `build-dir` | Path | Build directory of the CMake project. Defaults to the `build` directory inside the source directory. |
 | `targets` | Multiple strings | List of build targets. |
-| `run-test` | `true` or `false` | If enabled, runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
 | `generator` | String | Build system generator for the CMake project. |
 | `c-compiler` | String | Preferred executable for compiling C language files. |
 | `cxx-compiler` | String | Preferred executable for compiling C++ language files. |
 | `c-flags` | Multiple strings | Additional flags passed when compiling C language files. |
 | `cxx-flags` | Multiple strings | Additional flags passed when compiling C++ language files. |
 | `args` | Multiple strings | Additional arguments passed during CMake configuration. |
+| `run-test` | `true` or `false` | If enabled, runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). Defaults to `false`. |
 | `test-args` | Multiple strings | Additional arguments passed during the CTest run. |
 
 > Note: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.

--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,7 @@ inputs:
     description: The source directory of the CMake project
     required: false
   build-dir:
-    description: The source directory of the CMake project.
-    required: false
-  targets:
-    description: A list of build targets
+    description: The build directory of the CMake project
     required: false
   generator:
     description: The build system generator for the CMake project
@@ -24,24 +21,27 @@ inputs:
     description: The preferred executable for compiling C++ language files
     required: false
   c-flags:
-    description: Additional flags passed when compiling C language files
+    description: Additional flags to pass when compiling C language files
     required: false
   cxx-flags:
-    description: Additional flags passed when compiling C++ language files
+    description: Additional flags to pass when compiling C++ language files
     required: false
   args:
-    description: Additional arguments passed during the CMake configuration
+    description: Additional arguments to pass during the CMake configuration
     required: false
   run-build:
     description: If enabled, it builds the project using CMake (true/false)
     required: false
     default: false
+  build-args:
+    description: Additional arguments to pass during the CMake build
+    required: false
   run-test:
     description: If enabled, it runs testing using CTest (true/false)
     required: false
     default: false
   test-args:
-    description: Additional arguments passed during the CTest run
+    description: Additional arguments to pass during the CTest run
     required: false
 runs:
   using: composite
@@ -86,8 +86,8 @@ runs:
         if [ '${{ inputs.run-build }}' == 'true' ]; then
           BUILD_ARGS="--build '$BUILD_DIR'"
         fi
-        if [ -n '${{ inputs.targets }}' ]; then
-          BUILD_ARGS="$BUILD_ARGS --target ${{ inputs.targets }}"
+        if [ -n '${{ inputs.build-args }}' ]; then
+          BUILD_ARGS="$BUILD_ARGS ${{ inputs.build-args }}"
         fi
 
         TEST_ARGS=""

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         fi
         echo "cmake_args=${ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
 
-        if [ '${{ inputs.run-build }}' == 'true' ]; then
+        if [ '${{ inputs.run-build }}' == 'true' ] || [ '${{ inputs.run-test }}' == 'true' ]; then
           BUILD_ARGS="--build '$BUILD_DIR'"
           if [ -n '${{ inputs.build-args }}' ]; then
             BUILD_ARGS="$BUILD_ARGS ${{ inputs.build-args }}"
@@ -114,7 +114,7 @@ runs:
       run: cmake ${{ steps.process_inputs.outputs.cmake_args }}
 
     - name: Build targets
-      if: inputs.run-build != 'false'
+      if: inputs.run-build != 'false' || inputs.run-test != 'false'
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: cmake ${{ steps.process_inputs.outputs.cmake_build_args }}
 

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,6 @@ inputs:
   targets:
     description: List of build targets
     required: false
-  run-test:
-    description: If enabled, run testing using CTest (true/false)
-    required: false
-    default: false
   generator:
     description: Build system generator of the CMake project
     required: false
@@ -36,6 +32,10 @@ inputs:
   args:
     description: Additional arguments passed during the CMake configuration
     required: false
+  run-test:
+    description: If enabled, run testing using CTest (true/false)
+    required: false
+    default: false
   test-args:
     description: Additional arguments passed during the CTest run
     required: false
@@ -62,9 +62,6 @@ runs:
         if [ -n '${{ inputs.targets }}' ]; then
           BUILD_ARGS="$BUILD_ARGS --target ${{ inputs.targets }}"
         fi
-        if [ '${{ inputs.run-test }}' == 'true' ]; then
-          TEST_ARGS="--test-dir '$BUILD_DIR' --output-on-failure --no-tests=error"
-        fi
         if [ -n '${{ inputs.generator }}' ]; then
           ARGS="$ARGS -G '${{ inputs.generator }}'"
         fi
@@ -82,6 +79,9 @@ runs:
         fi
         if [ -n '${{ inputs.args }}' ]; then
           ARGS="$ARGS ${{ inputs.args }}"
+        fi
+        if [ '${{ inputs.run-test }}' == 'true' ]; then
+          TEST_ARGS="--test-dir '$BUILD_DIR' --output-on-failure --no-tests=error"
         fi
         if [ -n '${{ inputs.test-args }}' ]; then
           TEST_ARGS="$TEST_ARGS ${{ inputs.test-args }}"

--- a/action.yml
+++ b/action.yml
@@ -81,26 +81,23 @@ runs:
         if [ -n '${{ inputs.args }}' ]; then
           ARGS="$ARGS ${{ inputs.args }}"
         fi
+        echo "cmake_args=${ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
 
-        BUILD_ARGS=""
         if [ '${{ inputs.run-build }}' == 'true' ]; then
           BUILD_ARGS="--build '$BUILD_DIR'"
-        fi
-        if [ -n '${{ inputs.build-args }}' ]; then
-          BUILD_ARGS="$BUILD_ARGS ${{ inputs.build-args }}"
+          if [ -n '${{ inputs.build-args }}' ]; then
+            BUILD_ARGS="$BUILD_ARGS ${{ inputs.build-args }}"
+          fi
+          echo "cmake_build_args=${BUILD_ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
         fi
 
-        TEST_ARGS=""
         if [ '${{ inputs.run-test }}' == 'true' ]; then
           TEST_ARGS="--test-dir '$BUILD_DIR' --output-on-failure --no-tests=error"
+          if [ -n '${{ inputs.test-args }}' ]; then
+            TEST_ARGS="$TEST_ARGS ${{ inputs.test-args }}"
+          fi
+          echo "cmake_test_args=${TEST_ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
         fi
-        if [ -n '${{ inputs.test-args }}' ]; then
-          TEST_ARGS="$TEST_ARGS ${{ inputs.test-args }}"
-        fi
-
-        echo "cmake_args=${ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
-        echo "cmake_build_args=${BUILD_ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
-        echo "cmake_test_args=${TEST_ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
 
     - name: Install Ninja
       if: ${{ inputs.generator == 'Ninja' }}
@@ -117,11 +114,11 @@ runs:
       run: cmake ${{ steps.process_inputs.outputs.cmake_args }}
 
     - name: Build targets
-      if: steps.process_inputs.outputs.cmake_build_args != ''
+      if: inputs.run-build != 'false'
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: cmake ${{ steps.process_inputs.outputs.cmake_build_args }}
 
     - name: Run tests
-      if: steps.process_inputs.outputs.cmake_test_args != ''
+      if: inputs.run-test != 'false'
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: ctest ${{ steps.process_inputs.outputs.cmake_test_args }}

--- a/action.yml
+++ b/action.yml
@@ -6,22 +6,22 @@ branding:
   icon: terminal
 inputs:
   source-dir:
-    description: Source directory of the CMake project
+    description: The source directory of the CMake project
     required: false
   build-dir:
-    description: Build directory of the CMake project
+    description: The source directory of the CMake project.
     required: false
   targets:
-    description: List of build targets
+    description: A list of build targets
     required: false
   generator:
-    description: Build system generator of the CMake project
+    description: The build system generator for the CMake project
     required: false
   c-compiler:
-    description: Preferred executable for compiling C language files
+    description: The preferred executable for compiling C language files
     required: false
   cxx-compiler:
-    description: Preferred executable for compiling C++ language files
+    description: The preferred executable for compiling C++ language files
     required: false
   c-flags:
     description: Additional flags passed when compiling C language files
@@ -32,8 +32,12 @@ inputs:
   args:
     description: Additional arguments passed during the CMake configuration
     required: false
+  run-build:
+    description: If enabled, it builds the project using CMake (true/false)
+    required: false
+    default: false
   run-test:
-    description: If enabled, run testing using CTest (true/false)
+    description: If enabled, it runs testing using CTest (true/false)
     required: false
     default: false
   test-args:
@@ -50,18 +54,15 @@ runs:
         if [ -n '${{ inputs.source-dir }}' ]; then
           SOURCE_DIR="${{ inputs.source-dir }}"
         fi
+
         BUILD_DIR="build"
         if [ -n '${{ inputs.build-dir }}' ]; then
           BUILD_DIR="${{ inputs.build-dir }}"
         elif [ -n "${{ inputs.source-dir }}" ]; then
           BUILD_DIR="${{ inputs.source-dir }}/build"
         fi
+
         ARGS="'$SOURCE_DIR' -B '$BUILD_DIR'"
-        BUILD_ARGS="--build '$BUILD_DIR'"
-        TEST_ARGS=""
-        if [ -n '${{ inputs.targets }}' ]; then
-          BUILD_ARGS="$BUILD_ARGS --target ${{ inputs.targets }}"
-        fi
         if [ -n '${{ inputs.generator }}' ]; then
           ARGS="$ARGS -G '${{ inputs.generator }}'"
         fi
@@ -80,12 +81,23 @@ runs:
         if [ -n '${{ inputs.args }}' ]; then
           ARGS="$ARGS ${{ inputs.args }}"
         fi
+
+        BUILD_ARGS=""
+        if [ '${{ inputs.run-build }}' == 'true' ]; then
+          BUILD_ARGS="--build '$BUILD_DIR'"
+        fi
+        if [ -n '${{ inputs.targets }}' ]; then
+          BUILD_ARGS="$BUILD_ARGS --target ${{ inputs.targets }}"
+        fi
+
+        TEST_ARGS=""
         if [ '${{ inputs.run-test }}' == 'true' ]; then
           TEST_ARGS="--test-dir '$BUILD_DIR' --output-on-failure --no-tests=error"
         fi
         if [ -n '${{ inputs.test-args }}' ]; then
           TEST_ARGS="$TEST_ARGS ${{ inputs.test-args }}"
         fi
+
         echo "cmake_args=${ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
         echo "cmake_build_args=${BUILD_ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
         echo "cmake_test_args=${TEST_ARGS//[$'\t\r\n']}" >> $GITHUB_OUTPUT
@@ -105,6 +117,7 @@ runs:
       run: cmake ${{ steps.process_inputs.outputs.cmake_args }}
 
     - name: Build targets
+      if: steps.process_inputs.outputs.cmake_build_args != ''
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: cmake ${{ steps.process_inputs.outputs.cmake_build_args }}
 


### PR DESCRIPTION
# Default to No Build

- Update the action to only configure the CMake project by default, without building it.
- Introduce a new input `run-build` to control whether the project should be built directly from this action.
- Enabling the `run-test` option will automatically enable `run-build`.
- Replace the `targets` input with the `build-args` input.
- Simplify and refactor the `test.yml` workflow.
- Disable the "fail fast" feature for the job in the `test.yml` workflow that utilizes the matrix strategy.
- Merge the `specified-compiler-usage` and `specified-generator-usage` into `specified-generator-and-compiler-usage`.
- Closes #45.