### PR TITLE
Add `options` Input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           source-dir: test
           c-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           cxx-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
-          args: -D CHECK_SURPASS_WARNING=ON
+          options: CHECK_SURPASS_WARNING=ON
           run-build: true
           build-args: --target test_c --target test_cpp
           run-test: true
@@ -124,7 +124,7 @@ jobs:
           generator: Ninja
           c-compiler: clang
           cxx-compiler: clang++
-          args: -D CHECK_USING_CLANG=ON
+          options: CHECK_USING_CLANG=ON
           run-build: true
           build-args: --target test_c --target test_cpp
           run-test: true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 | `cxx-compiler` | String | The preferred executable for compiling C++ language files. |
 | `c-flags` | Multiple strings | Additional flags to pass when compiling C language files. |
 | `cxx-flags` | Multiple strings | Additional flags to pass when compiling C++ language files. |
+| `options` | Multiple strings | Additional options to pass during the CMake configuration. |
 | `args` | Multiple strings | Additional arguments to pass during the CMake configuration. |
 | `run-build` | `true` or `false` | If enabled, it builds the project using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). It defaults to `false`. |
 | `build-args` | Multiple strings | Additional arguments to pass during the CMake build. |
@@ -80,7 +81,7 @@ jobs:
 - name: Configure, build, and test the project
   uses: threeal/cmake-action@latest
   with:
-    args: -DBUILD_TESTING=ON
+    options: BUILD_TESTING=ON
     run-build: true
     run-test: true
 ```

--- a/README.md
+++ b/README.md
@@ -24,21 +24,21 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 | --- | --- | --- |
 | `source-dir` | Path | The source directory of the CMake project. It defaults to the current directory. |
 | `build-dir` | Path | The build directory of the CMake project. It defaults to the `build` directory inside the source directory. |
-| `generator` | String | The build system generator for the CMake project. |
-| `c-compiler` | String | The preferred executable for compiling C language files. |
-| `cxx-compiler` | String | The preferred executable for compiling C++ language files. |
-| `c-flags` | Multiple strings | Additional flags to pass when compiling C language files. |
-| `cxx-flags` | Multiple strings | Additional flags to pass when compiling C++ language files. |
-| `options` | Multiple strings | Additional options to pass during the CMake configuration. |
+| `generator` | String | The build system generator for the CMake project. It appends the CMake configuration arguments with `-G [val]`. |
+| `c-compiler` | String | The preferred executable for compiling C language files. It appends the CMake configuration arguments with `-D CMAKE_C_COMPILER=[val]`. |
+| `cxx-compiler` | String | The preferred executable for compiling C++ language files. It appends the CMake configuration arguments with `-D CMAKE_CXX_COMPILER=[val]`. |
+| `c-flags` | Multiple strings | Additional flags to pass when compiling C language files. It appends the CMake configuration arguments with `-D CMAKE_C_FLAGS=[vals]`. |
+| `cxx-flags` | Multiple strings | Additional flags to pass when compiling C++ language files. It appends the CMake configuration arguments with `-D CMAKE_CXX_FLAGS=[vals]`. |
+| `options` | Multiple strings | Additional options to pass during the CMake configuration. It appends the CMake configuration arguments with each of `-D [val]`. |
 | `args` | Multiple strings | Additional arguments to pass during the CMake configuration. |
-| `run-build` | `true` or `false` | If enabled, it builds the project using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). It defaults to `false`. |
+| `run-build` | `true` or `false` | If enabled, it builds the project using CMake. It defaults to `false`. |
 | `build-args` | Multiple strings | Additional arguments to pass during the CMake build. |
 | `run-test` | `true` or `false` | If enabled, it runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). It defaults to `false`. |
 | `test-args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
-> Note: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.
+> **Note**: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.
 
-> Note: All inputs are optional.
+> **Note**: All inputs are optional.
 
 ### Examples
 
@@ -63,7 +63,7 @@ jobs:
         runs: ctest --test-dir build
 ```
 
-> Note: You can replace `@latest` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
+> **Note**: You can replace `@latest` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
 #### Specify the Source and Build Directories
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.3
 
       - name: Configure the project
-        uses: threeal/cmake-action@latest
+        uses: threeal/cmake-action@main
 
       - name: Build the project
         runs: cmake --build build
@@ -63,13 +63,13 @@ jobs:
         runs: ctest --test-dir build
 ```
 
-> **Note**: You can replace `@latest` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
+> **Note**: You can replace `@main` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
 #### Specify the Source and Build Directories
 
 ```yaml
 - name: Configure the project
-  uses: threeal/cmake-action@latest
+  uses: threeal/cmake-action@main
   with:
     source-dir: submodules
     build-dir: submodules/out
@@ -79,7 +79,7 @@ jobs:
 
 ```yaml
 - name: Configure, build, and test the project
-  uses: threeal/cmake-action@latest
+  uses: threeal/cmake-action@main
   with:
     options: BUILD_TESTING=ON
     run-build: true
@@ -90,7 +90,7 @@ jobs:
 
 ```yaml
 - name: Configure and build the project
-  uses: threeal/cmake-action@latest
+  uses: threeal/cmake-action@main
   with:
     generator: Ninja
     c-compiler: clang

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   cxx-flags:
     description: Additional flags to pass when compiling C++ language files
     required: false
+  options:
+    description: Additional options to pass during the CMake configuration
+    required: false
   args:
     description: Additional arguments to pass during the CMake configuration
     required: false
@@ -78,6 +81,9 @@ runs:
         if [ -n '${{ inputs.cxx-flags }}' ]; then
           ARGS="$ARGS -D CMAKE_CXX_FLAGS='${{ inputs.cxx-flags }}'"
         fi
+        for OPT in ${{ inputs.options }}; do
+          ARGS="$ARGS -D $OPT"
+        done
         if [ -n '${{ inputs.args }}' ]; then
           ARGS="$ARGS ${{ inputs.args }}"
         fi


### PR DESCRIPTION
- Introduce a new input `options` to allow users to specify additional options to pass during the CMake configuration.
- Enhance the clarity and readability of the `README.md` file.
- Closes #35.