### PR TITLE
Adjust Recommended Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Configure the project
-        uses: threeal/cmake-action@main
+        uses: threeal/cmake-action@v1.2.0
 
       - name: Build the project
         runs: cmake --build build
@@ -63,13 +63,13 @@ jobs:
         runs: ctest --test-dir build
 ```
 
-> **Note**: You can replace `@main` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
+> **Note**: You can replace [`v1.2.0`](https://github.com/threeal/cmake-action/releases/tag/v1.2.0) with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
 #### Specify the Source and Build Directories
 
 ```yaml
 - name: Configure the project
-  uses: threeal/cmake-action@main
+  uses: threeal/cmake-action@v1.2.0
   with:
     source-dir: submodules
     build-dir: submodules/out
@@ -79,7 +79,7 @@ jobs:
 
 ```yaml
 - name: Configure, build, and test the project
-  uses: threeal/cmake-action@main
+  uses: threeal/cmake-action@v1.2.0
   with:
     options: BUILD_TESTING=ON
     run-build: true
@@ -90,7 +90,7 @@ jobs:
 
 ```yaml
 - name: Configure and build the project
-  uses: threeal/cmake-action@main
+  uses: threeal/cmake-action@v1.2.0
   with:
     generator: Ninja
     c-compiler: clang


### PR DESCRIPTION
To provide more flexibility for users, it is recommended to specify the latest version tag of this action instead of using `@latest` or `@main`. This allows users to choose the desired version without being forced to use the latest version of the action.