### PR TITLE
Remove Custom Shell Input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,16 +162,3 @@ jobs:
           build-args: --target test_c --target test_cpp
           run-test: true
           test-args: -R test
-
-  specified-shell:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4.1.1
-
-      - name: Use the action with specified shell
-        uses: ./
-        with:
-          shell: bash
-          source-dir: test
-          run-build: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 
 | Name | Value Type | Description |
 | --- | --- | --- |
-| `shell` | String | The shell to be used to run the commands. It defaults to `pwsh` on Windows and `bash` on Linux and macOS. Refer to [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell) for more information on available shell options. |
 | `source-dir` | Path | The source directory of the CMake project. It defaults to the current directory. |
 | `build-dir` | Path | The build directory of the CMake project. It defaults to the `build` directory inside the source directory. |
 | `generator` | String | The build system generator for the CMake project. It appends the CMake configuration arguments with `-G [val]`. |

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,6 @@ branding:
   color: gray-dark
   icon: terminal
 inputs:
-  shell:
-    description: The shell to be used to run the commands
-    required: false
   source-dir:
     description: The source directory of the CMake project
     required: false


### PR DESCRIPTION
This pull request removes the `shell` action input. It also removes the `specified-shell` job from the Test workflow. It closes #79.