### PR TITLE
Install Ninja if It Was Not Available

### DIFF
--- a/main/index.mjs
+++ b/main/index.mjs
@@ -27238,6 +27238,8 @@ var __webpack_exports__ = {};
 (() => {
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2340);
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(4926);
+/* harmony import */ var _actions_io__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(1793);
+
 
 
 async function main() {
@@ -27247,7 +27249,7 @@ async function main() {
     const generator = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("generator");
     if (generator)
         configureArgs.push(...["-G", generator]);
-    if (generator.match(/ninja/gi)) {
+    if (generator.match(/ninja/gi) && !(await _actions_io__WEBPACK_IMPORTED_MODULE_2__.which("ninja"))) {
         switch (process.platform) {
             case "linux":
                 await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("sudo", ["apt", "install", "-y", "ninja-build"]);

--- a/main/index.mjs
+++ b/main/index.mjs
@@ -27247,6 +27247,19 @@ async function main() {
     const generator = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("generator");
     if (generator)
         configureArgs.push(...["-G", generator]);
+    if (generator.match(/ninja/gi)) {
+        switch (process.platform) {
+            case "linux":
+                await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("sudo", ["apt", "install", "-y", "ninja-build"]);
+                break;
+            case "darwin":
+                await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("brew", ["install", "ninja"]);
+                break;
+            case "win32":
+                await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("choco", ["install", "ninja"]);
+                break;
+        }
+    }
     const cCompiler = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput("c-compiler");
     if (cCompiler)
         configureArgs.push("-DCMAKE_C_COMPILER=" + cCompiler);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@actions/exec": "^1.1.1"
+    "@actions/exec": "^1.1.1",
+    "@actions/io": "^1.1.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,5 +1,6 @@
 import core from "@actions/core";
 import exec from "@actions/exec";
+import io from "@actions/io";
 
 async function main() {
   const sourceDir = core.getInput("source-dir");
@@ -10,7 +11,7 @@ async function main() {
   const generator = core.getInput("generator");
   if (generator) configureArgs.push(...["-G", generator]);
 
-  if (generator.match(/ninja/gi)) {
+  if (generator.match(/ninja/gi) && !(await io.which("ninja"))) {
     switch (process.platform) {
       case "linux":
         await exec.exec("sudo", ["apt", "install", "-y", "ninja-build"]);

--- a/src/main.mts
+++ b/src/main.mts
@@ -10,6 +10,20 @@ async function main() {
   const generator = core.getInput("generator");
   if (generator) configureArgs.push(...["-G", generator]);
 
+  if (generator.match(/ninja/gi)) {
+    switch (process.platform) {
+      case "linux":
+        await exec.exec("sudo", ["apt", "install", "-y", "ninja-build"]);
+        break;
+      case "darwin":
+        await exec.exec("brew", ["install", "ninja"]);
+        break;
+      case "win32":
+        await exec.exec("choco", ["install", "ninja"]);
+        break;
+    }
+  }
+
   const cCompiler = core.getInput("c-compiler");
   if (cCompiler) configureArgs.push("-DCMAKE_C_COMPILER=" + cCompiler);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/io@npm:^1.0.1":
+"@actions/io@npm:^1.0.1, @actions/io@npm:^1.1.3":
   version: 1.1.3
   resolution: "@actions/io@npm:1.1.3"
   checksum: 5b8751918e5bf0bebd923ba917fb1c0e294401e7ff0037f32c92a4efa4215550df1f6633c63fd4efb2bdaae8711e69b9e36925857db1f38935ff62a5c92ec29e
@@ -1617,6 +1617,7 @@ __metadata:
   dependencies:
     "@actions/core": "npm:^1.10.1"
     "@actions/exec": "npm:^1.1.1"
+    "@actions/io": "npm:^1.1.3"
     "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.8"
     "@types/node": "npm:^20.9.0"


### PR DESCRIPTION
This pull request adds a step to install [Ninja](https://ninja-build.org/) using system package manager if `ninja` command is not available in the system. It fixes failure on the `specified-generator-and-compiler-usage` job. It closes #80.