### PR TITLE
Add Git Attributes for Yarn Lock File and Adjust Other Rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-main/index.mjs -diff linguist-generated=true
+main/index.mjs -diff linguist-generated
 yarn.lock -diff linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 main/index.mjs -diff linguist-generated=true
+yarn.lock -diff linguist-generated


### PR DESCRIPTION
This pull request introduces the following changes:
- Set the Git attributes for the `yarn.lock` file to mark it as generated and disable diff for that file.
- Adjust the style of Git attributes for the `main/index.mjs` file.

It closes #92.