### PR TITLE
Use `.gitignore` in ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "root": true,
+  "ignorePatterns": ["main"],
   "extends": ["eslint:recommended", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "bundle": "tsc && ncc build dist/main.mjs -o main",
-    "check": "prettier --write . !main !README.md && eslint src package.json",
+    "check": "prettier --write . !main !README.md && eslint --ignore-path .gitignore .",
     "test": "tsc && jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull requests modify ESLint to use `.gitignore` for ignoring files. It also excludes the `main` directory from ESLint checks. It closes #111.