### PR TITLE
Add Check Package Job in Test Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,4 @@ jobs:
         run: yarn install
 
       - name: Bundle Package
-        run: yarn bundle
-
-      - name: Check Differences
-        run: git diff --exit-code HEAD
+        run: yarn bundle && git diff --exit-code HEAD

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,12 +29,6 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Check Format
-        run: yarn format
-
-      - name: Check Lint
-        run: yarn lint
-
       - name: Bundle Package
         run: yarn bundle
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Update Yarn
-        run: corepack enable && yarn set version stable
+      - name: Enable Yarn
+        run: corepack enable yarn
 
       - name: Cache Dependencies
         uses: actions/cache@v3.3.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Enable Yarn
         run: corepack enable yarn
 
+      - name: Check Yarn Version
+        run: yarn set version stable && git diff --exit-code HEAD
+
       - name: Cache Dependencies
         uses: actions/cache@v3.3.2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,36 @@ on:
   push:
     branches: [main]
 jobs:
+  check-package:
+    name: Check Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: latest
+
+      - name: Enable Yarn
+        run: corepack enable yarn
+
+      - name: Cache Dependencies
+        uses: actions/cache@v3.3.2
+        with:
+          path: .yarn
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Check Format
+        run: yarn format && git diff --exit-code HEAD
+
+      - name: Check Lint
+        run: yarn lint
+
   test-package:
     name: Test Package
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds a `check-package` job in the `test.yaml` workflow for checking Yarn version, code formatting, and static lint. It also modifies some steps in the `build-package` job. It closes #117.