### PR TITLE
Use LTS Version of Node.js in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: latest
+          node-version: 20
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: latest
+          node-version: 20
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: latest
+          node-version: 20
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0


### PR DESCRIPTION
This pull request modifies `Setup Node.js` steps in workflows to setup Node.js to version `20` (current LTS version). It closes #129.