### PR TITLE
Audit TypeScript Configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "nodenext",
+    "module": "node16",
     "declaration": true,
     "outDir": "dist",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "NodeNext",
+    "module": "nodenext",
     "declaration": true,
     "outDir": "dist",
     "sourceMap": true,
-    "target": "ES2022",
+    "target": "es2022",
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,9 @@
   "compilerOptions": {
     "strict": true,
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "dist",
     "sourceMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2022"],
     "target": "ES2022",
     "skipLibCheck": true
   },


### PR DESCRIPTION
This pull request introduces the following changes to the `tsconfig.json` file:
- Removes the following unnecessary compiler options:
  - `moduleResolution`, already defaults to the same as `module` option.
  - `esModuleInterop`, already defaults to true if using `node16` or `nodenext`.
  - `forceConsistentCasingInFileNames`, already defaults to true.
  - `lib`, not required in this project.
- Adds a `exactOptionalPropertyTypes` compiler option that set to true.
- Use `node16` module instead of `nodenext`.
- Adjust `module` and `target` compiler options to use lowercase values.

It closes #131.