### PR TITLE
Call Yarn Command From Corepack Command in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,4 +21,6 @@ jobs:
         uses: threeal/yarn-install-action@v1.0.0
 
       - name: Build Package
-        run: yarn build && git diff --exit-code HEAD
+        run: |
+          corepack yarn build
+          git diff --exit-code HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,13 +21,17 @@ jobs:
         uses: threeal/yarn-install-action@v1.0.0
 
       - name: Check Yarn Version
-        run: yarn set version stable && git diff --exit-code HEAD
+        run: |
+          corepack yarn set version stable
+          git diff --exit-code HEAD
 
       - name: Check Format
-        run: yarn format && git diff --exit-code HEAD
+        run: |
+          corepack yarn format
+          git diff --exit-code HEAD
 
       - name: Check Lint
-        run: yarn lint
+        run: corepack yarn lint
 
   test-package:
     name: Test Package
@@ -45,7 +49,7 @@ jobs:
         uses: threeal/yarn-install-action@v1.0.0
 
       - name: Test Package
-        run: yarn test
+        run: corepack yarn test
         env:
           NODE_OPTIONS: --experimental-vm-modules
 


### PR DESCRIPTION
This pull request modifies the `yarn` command to be called with `corepack yarn` instead in the workflows. It closes #133.