### PR TITLE
Remove Package Name in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "cmake-action",
   "private": true,
   "type": "module",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,27 +1674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cmake-action@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "cmake-action@workspace:."
-  dependencies:
-    "@actions/core": "npm:^1.10.1"
-    "@actions/exec": "npm:^1.1.1"
-    "@actions/io": "npm:^1.1.3"
-    "@types/node": "npm:^20.11.10"
-    "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
-    "@typescript-eslint/parser": "npm:^6.21.0"
-    "@vercel/ncc": "npm:^0.38.1"
-    eslint: "npm:^8.56.0"
-    eslint-config-prettier: "npm:^9.1.0"
-    eslint-plugin-json-files: "npm:^4.1.0"
-    eslint-plugin-tsdoc: "npm:^0.2.17"
-    jest: "npm:^29.7.0"
-    prettier: "npm:^3.2.5"
-    typescript: "npm:^5.3.3"
-  languageName: unknown
-  linkType: soft
-
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -4047,6 +4026,27 @@ __metadata:
   checksum: 9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
   languageName: node
   linkType: hard
+
+"root-workspace-0b6124@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "root-workspace-0b6124@workspace:."
+  dependencies:
+    "@actions/core": "npm:^1.10.1"
+    "@actions/exec": "npm:^1.1.1"
+    "@actions/io": "npm:^1.1.3"
+    "@types/node": "npm:^20.11.10"
+    "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
+    "@typescript-eslint/parser": "npm:^6.21.0"
+    "@vercel/ncc": "npm:^0.38.1"
+    eslint: "npm:^8.56.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-json-files: "npm:^4.1.0"
+    eslint-plugin-tsdoc: "npm:^0.2.17"
+    jest: "npm:^29.7.0"
+    prettier: "npm:^3.2.5"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
 
 "run-parallel@npm:^1.1.9":
   version: 1.2.0


### PR DESCRIPTION
This pull request resolves #180 by removing the `name` field from the `package.json` file.