### PR TITLE
Setup Latest Node.js in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: 20
+          node-version: latest
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: 20
+          node-version: latest
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: 20
+          node-version: latest
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0


### PR DESCRIPTION
This pull request resolves #186 by modifying the `Setup Node.js` steps in all workflows to setup the latest version of Node.js.