### PR TITLE
Fix Git Ignore Pattern for JavaScript Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ build/
 coverage/
 node_modules/
 
-src/*.mjs
+src/**/*.mjs


### PR DESCRIPTION
This pull request resolves #103 by fixing the pattern in the `.gitignore` file to ignore JavaScript files using `src/**/*.mjs`.