### PR TITLE
Use Prettier with Cache Enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && ncc build src/index.mjs -o dist",
-    "format": "prettier --write . !dist !README.md",
+    "format": "prettier --write --cache . !dist !README.md",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "tsc && jest"
   },


### PR DESCRIPTION
This pull request resolves #191 by modifying the `format` script to call the `prettier` command with the `--cache` option enabled.