### PR TITLE
Use Default ncc Build Output

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "ncc build src/index.ts -o dist",
+    "build": "ncc build src/index.ts",
     "format": "prettier --write --cache . !dist !README.md",
     "lint": "eslint --ignore-path .gitignore ."
   },


### PR DESCRIPTION
This pull request resolves #222 by removing the `-o dist` option when calling the `ncc` command, effectively causing the `ncc` command to output the build result to the default directory, which is also the `dist` directory.