### PR TITLE
Remove Support for Testing CMake Projects

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -141,26 +141,6 @@ jobs:
       - name: Test Project
         run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R test
 
-  test-action-with-run-test:
-    name: Test Action With Run Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.2
-        with:
-          sparse-checkout: |
-            action.yml
-            dist
-            test
-          sparse-checkout-cone-mode: false
-
-      - name: Configure, Build, and Test Project
-        uses: ./
-        with:
-          source-dir: test
-          run-test: true
-          test-args: -R hello_world
-
   test-action-with-additional-args:
     name: Test Action With Additional Arguments
     runs-on: ${{ matrix.compiler == 'msvc' && 'windows' || 'ubuntu' }}-latest
@@ -187,8 +167,6 @@ jobs:
           options: CHECK_SURPASS_WARNING=ON
           run-build: true
           build-args: --target test_c --target test_cpp
-          run-test: true
-          test-args: -R test ${{ matrix.compiler == 'msvc' && '-C Debug' || '' }}
 
   test-action-with-custom-tools:
     name: Test Action With Custom Tools
@@ -217,5 +195,3 @@ jobs:
           options: CHECK_USING_CLANG=ON
           run-build: true
           build-args: --target test_c --target test_cpp
-          run-test: true
-          test-args: -R test

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 | `args` | Multiple strings | Additional arguments to pass during the CMake configuration. |
 | `run-build` | `true` or `false` | If enabled, it builds the project using CMake. It defaults to `false`. |
 | `build-args` | Multiple strings | Additional arguments to pass during the CMake build. |
-| `run-test` | `true` or `false` | If enabled, it runs testing using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html). It defaults to `false`. |
-| `test-args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
 > **Note**: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.
 
@@ -61,21 +59,17 @@ jobs:
 
       - name: Build Project
         runs: cmake --build build
-
-      - name: Test Project
-        runs: ctest --test-dir build
 ```
 
 > **Note**: You can replace [`v1.3.0`](https://github.com/threeal/cmake-action/releases/tag/v1.3.0) with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
-#### Configure, Build, and Test in the Same Step
+#### Configure and Build in the Same Step
 
 ```yaml
 - name: Configure, Build, and Test Project
   uses: threeal/cmake-action@v1.3.0
   with:
     run-build: true
-    run-test: true
 ```
 
 #### Specify the Source and Build Directories

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # CMake Action
 
-Configure, build, and test your [CMake](https://cmake.org/) project using [GitHub Actions](https://github.com/features/actions). This action simplifies the workflow for configuring the build environment of a CMake project. It can also be optionally specified to build a CMake project using the `cmake --build` command and test it using the `ctest` command.
+Configure and build your [CMake](https://cmake.org/) project using [GitHub Actions](https://github.com/features/actions). This action simplifies the workflow for configuring the build environment of a CMake project. It can also be optionally specified to build a CMake project using the `cmake --build` command.
 
 ## Features
 
 - Configures a CMake project using the [`cmake`](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command.
 - Optionally builds a CMake project using the `cmake --build` command.
-- Optionally tests a CMake project using the [`ctest`](https://cmake.org/cmake/help/latest/manual/ctest.1.html) command.
 - Auto-detects and installs required dependencies.
 - Supports specifying multiple CMake options directly from the action inputs.
 
@@ -66,7 +65,7 @@ jobs:
 #### Configure and Build in the Same Step
 
 ```yaml
-- name: Configure, Build, and Test Project
+- name: Configure and Build Project
   uses: threeal/cmake-action@v1.3.0
   with:
     run-build: true

--- a/action.yml
+++ b/action.yml
@@ -28,11 +28,6 @@ inputs:
     default: false
   build-args:
     description: Additional arguments to pass during the CMake build
-  run-test:
-    description: If enabled, it runs testing using CTest (true/false)
-    default: false
-  test-args:
-    description: Additional arguments to pass during the CTest run
 outputs:
   build-dir:
     description: The build directory of the CMake project

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: CMake Action
-description: Configure, build, and test your CMake project
+description: Configure and build your CMake project
 author: Alfi Maulana
 branding:
   color: gray-dark

--- a/dist/index.js
+++ b/dist/index.js
@@ -27715,8 +27715,6 @@ function getInputs() {
         args: (0,core.getMultilineInput)("args").flatMap((args) => args.split(" ")),
         runBuild: (0,core.getBooleanInput)("run-build"),
         buildArgs: (0,core.getMultilineInput)("build-args").flatMap((args) => args.split(" ")),
-        testArgs: (0,core.getMultilineInput)("test-args").flatMap((args) => args.split(" ")),
-        runTest: (0,core.getBooleanInput)("run-test"),
     };
 }
 
@@ -27760,17 +27758,8 @@ async function main() {
     configureArgs.push(...inputs.args);
     await (0,exec.exec)("cmake", configureArgs);
     core.setOutput("build-dir", inputs.buildDir);
-    if (inputs.runBuild || inputs.runTest) {
+    if (inputs.runBuild) {
         await (0,exec.exec)("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
-    }
-    if (inputs.runTest) {
-        await (0,exec.exec)("ctest", [
-            "--test-dir",
-            inputs.buildDir,
-            "--output-on-failure",
-            "--no-tests=error",
-            ...inputs.testArgs,
-        ]);
     }
 }
 main().catch((err) => core.setFailed(err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,18 +48,8 @@ async function main() {
   await exec("cmake", configureArgs);
   core.setOutput("build-dir", inputs.buildDir);
 
-  if (inputs.runBuild || inputs.runTest) {
+  if (inputs.runBuild) {
     await exec("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
-  }
-
-  if (inputs.runTest) {
-    await exec("ctest", [
-      "--test-dir",
-      inputs.buildDir,
-      "--output-on-failure",
-      "--no-tests=error",
-      ...inputs.testArgs,
-    ]);
   }
 }
 

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -35,8 +35,6 @@ describe("get action inputs", () => {
         args: [],
         runBuild: false,
         buildArgs: [],
-        runTest: false,
-        testArgs: [],
       });
     });
   });
@@ -50,8 +48,6 @@ describe("get action inputs", () => {
       jest.mocked(getBooleanInput).mockImplementation((name) => {
         switch (name) {
           case "run-build":
-            return true;
-          case "run-test":
             return true;
         }
         throw new Error(`invalid input name: ${name}`);
@@ -88,8 +84,6 @@ describe("get action inputs", () => {
               "some-build-args another-build-args",
               "some-other-build-args",
             ];
-          case "test-args":
-            return ["some-test-args another-test-args", "some-other-test-args"];
         }
         throw new Error(`invalid input name: ${name}`);
       });
@@ -115,12 +109,6 @@ describe("get action inputs", () => {
           "some-build-args",
           "another-build-args",
           "some-other-build-args",
-        ],
-        runTest: true,
-        testArgs: [
-          "some-test-args",
-          "another-test-args",
-          "some-other-test-args",
         ],
       });
     });

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -12,8 +12,6 @@ export interface Inputs {
   args: string[];
   runBuild: boolean;
   buildArgs: string[];
-  runTest: boolean;
-  testArgs: string[];
 }
 
 export function getInputs(): Inputs {
@@ -31,7 +29,5 @@ export function getInputs(): Inputs {
     buildArgs: getMultilineInput("build-args").flatMap((args) =>
       args.split(" "),
     ),
-    testArgs: getMultilineInput("test-args").flatMap((args) => args.split(" ")),
-    runTest: getBooleanInput("run-test"),
   };
 }


### PR DESCRIPTION
This pull request resolves #255 by removing the `run-test` and `test-args` action inputs. It also removes descriptions in the documentation that imply that this action supports testing.