### PR TITLE
Remove Support for Auto Install Ninja

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -185,6 +185,9 @@ jobs:
             test
           sparse-checkout-cone-mode: false
 
+      - name: Setup Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v4
+
       - name: Configure, Build, and Test Project
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Configure and build your [CMake](https://cmake.org/) project using [GitHub Actio
 
 - Configures a CMake project using the [`cmake`](https://cmake.org/cmake/help/latest/manual/cmake.1.html) command.
 - Optionally builds a CMake project using the `cmake --build` command.
-- Auto-detects and installs required dependencies.
 - Supports specifying multiple CMake options directly from the action inputs.
 
 ## Usage
@@ -84,6 +83,9 @@ jobs:
 #### Using Ninja as the Generator and Clang as the Compiler
 
 ```yaml
+- name: Setup Ninja
+  uses: seanmiddleditch/gha-setup-ninja@v4
+
 - name: Configure Project
   uses: threeal/cmake-action@v1.3.0
   with:

--- a/dist/index.js
+++ b/dist/index.js
@@ -27698,8 +27698,6 @@ var __webpack_exports__ = {};
 var core = __nccwpck_require__(2340);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(4926);
-// EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-io-npm-1.1.3-82d1cf012b-10c0.zip/node_modules/@actions/io/lib/io.js
-var io = __nccwpck_require__(1793);
 ;// CONCATENATED MODULE: ./src/inputs.ts
 
 function getInputs() {
@@ -27722,25 +27720,11 @@ function getInputs() {
 
 
 
-
 async function main() {
     const inputs = getInputs();
     const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
     if (inputs.generator) {
         configureArgs.push(...["-G", inputs.generator]);
-    }
-    if (inputs.generator.match(/ninja/gi) && !(await (0,io.which)("ninja"))) {
-        switch (process.platform) {
-            case "linux":
-                await (0,exec.exec)("sudo", ["apt", "install", "-y", "ninja-build"]);
-                break;
-            case "darwin":
-                await (0,exec.exec)("brew", ["install", "ninja"]);
-                break;
-            case "win32":
-                await (0,exec.exec)("choco", ["install", "ninja"]);
-                break;
-        }
     }
     if (inputs.cCompiler) {
         configureArgs.push("-DCMAKE_C_COMPILER=" + inputs.cCompiler);

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@actions/exec": "^1.1.1",
-    "@actions/io": "^1.1.3"
+    "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as core from "@actions/core";
 import { exec } from "@actions/exec";
-import { which } from "@actions/io";
 import { getInputs } from "./inputs.js";
 
 async function main() {
@@ -10,20 +9,6 @@ async function main() {
 
   if (inputs.generator) {
     configureArgs.push(...["-G", inputs.generator]);
-  }
-
-  if (inputs.generator.match(/ninja/gi) && !(await which("ninja"))) {
-    switch (process.platform) {
-      case "linux":
-        await exec("sudo", ["apt", "install", "-y", "ninja-build"]);
-        break;
-      case "darwin":
-        await exec("brew", ["install", "ninja"]);
-        break;
-      case "win32":
-        await exec("choco", ["install", "ninja"]);
-        break;
-    }
   }
 
   if (inputs.cCompiler) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/io@npm:^1.0.1, @actions/io@npm:^1.1.3":
+"@actions/io@npm:^1.0.1":
   version: 1.1.3
   resolution: "@actions/io@npm:1.1.3"
   checksum: 10c0/5b8751918e5bf0bebd923ba917fb1c0e294401e7ff0037f32c92a4efa4215550df1f6633c63fd4efb2bdaae8711e69b9e36925857db1f38935ff62a5c92ec29e
@@ -3857,7 +3857,6 @@ __metadata:
   dependencies:
     "@actions/core": "npm:^1.10.1"
     "@actions/exec": "npm:^1.1.1"
-    "@actions/io": "npm:^1.1.3"
     "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.28"


### PR DESCRIPTION
This pull request resolves #257 by removing support for auto-installing [Ninja](https://ninja-build.org/) when the generator is set as Ninja. It also adds a new step in the `test-action-with-custom-tools` job to set up Ninja using the [seanmiddleditch/gha-setup-ninja](https://github.com/seanmiddleditch/gha-setup-ninja) action to accommodate this change for testing the `generator` input.