### PR TITLE
Modify Action Default to Run Build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,55 +70,15 @@ jobs:
       - name: Move Project
         run: mv test/* .
 
-      - name: Configure Project
+      - name: Configure and Build Project
         id: cmake-action
         uses: ./
 
-      - name: Try to Test Project
-        id: failed-step
-        continue-on-error: true
+      - name: Test Project
         run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world ${{ matrix.os == 'windows' && '-C Debug' || '' }}
-
-      - name: Previous Step Should Failed
-        if: steps.failed-step.outcome == 'success'
-        run: exit 1
-
-      - name: Build and Test Project
-        run: |
-          cmake --build ${{ steps.cmake-action.outputs.build-dir }}
-          ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world ${{ matrix.os == 'windows' && '-C Debug' || '' }}
 
   test-action-with-specified-dirs:
     name: Test Action With Specified Directories
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.2
-        with:
-          sparse-checkout: |
-            action.yml
-            dist
-            test
-          sparse-checkout-cone-mode: false
-
-      - name: Configure Project
-        id: cmake-action
-        uses: ./
-        with:
-          source-dir: test
-          build-dir: output
-
-      - name: Default Build Directory Should Not Exist
-        shell: bash
-        run: test ! -e build && test ! -e test/build
-
-      - name: Build and Test Project
-        run: |
-          cmake --build ${{ steps.cmake-action.outputs.build-dir }}
-          ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world
-
-  test-action-with-run-build:
-    name: Test Action With Run Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -135,11 +95,43 @@ jobs:
         uses: ./
         with:
           source-dir: test
-          run-build: true
-          build-args: --target test_c --target test_cpp
+          build-dir: output
+
+      - name: Default Build Directory Should Not Exist
+        shell: bash
+        run: test ! -e build && test ! -e test/build
 
       - name: Test Project
-        run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R test
+        run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world
+
+  test-action-without-run-build:
+    name: Test Action Without Run Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+        with:
+          sparse-checkout: |
+            action.yml
+            dist
+            test
+          sparse-checkout-cone-mode: false
+
+      - name: Configure Project
+        id: cmake-action
+        uses: ./
+        with:
+          source-dir: test
+          run-build: false
+
+      - name: Try to Test Project
+        id: failed-step
+        continue-on-error: true
+        run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world
+
+      - name: Previous Step Should Failed
+        if: steps.failed-step.outcome == 'success'
+        run: exit 1
 
   test-action-with-additional-args:
     name: Test Action With Additional Arguments
@@ -165,7 +157,6 @@ jobs:
           c-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           cxx-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           options: CHECK_SURPASS_WARNING=ON
-          run-build: true
           build-args: --target test_c --target test_cpp
 
   test-action-with-custom-tools:
@@ -196,5 +187,4 @@ jobs:
           c-compiler: clang
           cxx-compiler: clang++
           options: CHECK_USING_CLANG=ON
-          run-build: true
           build-args: --target test_c --target test_cpp

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 | `cxx-flags` | Multiple strings | Additional flags to pass when compiling C++ language files. It appends the CMake configuration arguments with `-D CMAKE_CXX_FLAGS=[vals]`. |
 | `options` | Multiple strings | Additional options to pass during the CMake configuration. It appends the CMake configuration arguments with each of `-D [val]`. |
 | `args` | Multiple strings | Additional arguments to pass during the CMake configuration. |
-| `run-build` | `true` or `false` | If enabled, it builds the project using CMake. It defaults to `false`. |
+| `run-build` | `true` or `false` | If enabled, it builds the project using CMake. It defaults to `true`. |
 | `build-args` | Multiple strings | Additional arguments to pass during the CMake build. |
 
 > **Note**: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.
@@ -52,29 +52,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.2
 
-      - name: Configure Project
-        uses: threeal/cmake-action@v1.3.0
-
-      - name: Build Project
-        runs: cmake --build build
+      - name: Configure and Build Project
+        uses: threeal/cmake-action@main
 ```
 
-> **Note**: You can replace [`v1.3.0`](https://github.com/threeal/cmake-action/releases/tag/v1.3.0) with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
+> **Note**: You can replace `main` with any version you prefer. See [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
-#### Configure and Build in the Same Step
+#### Configure Project Without Building
 
 ```yaml
-- name: Configure and Build Project
-  uses: threeal/cmake-action@v1.3.0
+- name: Configure Project
+  uses: threeal/cmake-action@main
   with:
-    run-build: true
+    run-build: false
 ```
 
 #### Specify the Source and Build Directories
 
 ```yaml
-- name: Configure Project
-  uses: threeal/cmake-action@v1.3.0
+- name: Configure and Build Project
+  uses: threeal/cmake-action@main
   with:
     source-dir: submodules
     build-dir: submodules/out
@@ -86,8 +83,8 @@ jobs:
 - name: Setup Ninja
   uses: seanmiddleditch/gha-setup-ninja@v4
 
-- name: Configure Project
-  uses: threeal/cmake-action@v1.3.0
+- name: Configure and Build Project
+  uses: threeal/cmake-action@main
   with:
     generator: Ninja
     c-compiler: clang

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: Additional arguments to pass during the CMake configuration
   run-build:
     description: If enabled, it builds the project using CMake (true/false)
-    default: false
+    default: true
   build-args:
     description: Additional arguments to pass during the CMake build
 outputs:


### PR DESCRIPTION
This pull request resolves #259 by modifying the `run-build` input to default to `true`, effectively causing the CMake action to always build the project, inverting the previous behavior.