### PR TITLE
Utilize CTest Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
             test
           sparse-checkout-cone-mode: false
 
-      - name: Configure, Build, and Test Project
+      - name: Configure and Build Project
         uses: ./
         with:
           source-dir: test
@@ -166,6 +166,12 @@ jobs:
           cxx-flags: ${{ matrix.compiler == 'msvc' && '/w /WX-' || '-Wno-unused-variable' }}
           options: CHECK_SURPASS_WARNING=ON
           build-args: --target test_c --target test_cpp
+
+      - name: Test Project
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          build-config: Debug
+          tests-regex: test
 
   test-action-with-custom-tools:
     name: Test Action With Custom Tools
@@ -187,7 +193,7 @@ jobs:
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v4
 
-      - name: Configure, Build, and Test Project
+      - name: Configure and Build Project
         uses: ./
         with:
           source-dir: test
@@ -196,3 +202,8 @@ jobs:
           cxx-compiler: clang++
           options: CHECK_USING_CLANG=ON
           build-args: --target test_c --target test_cpp
+
+      - name: Test Project
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          tests-regex: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,7 +75,10 @@ jobs:
         uses: ./
 
       - name: Test Project
-        run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world ${{ matrix.os == 'windows' && '-C Debug' || '' }}
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          build-config: Debug
+          tests-regex: hello_world
 
   test-action-with-specified-dirs:
     name: Test Action With Specified Directories
@@ -102,7 +105,10 @@ jobs:
         run: test ! -e build && test ! -e test/build
 
       - name: Test Project
-        run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          test-dir: ${{ steps.cmake-action.outputs.build-dir }}
+          tests-regex: hello_world
 
   test-action-without-run-build:
     name: Test Action Without Run Build
@@ -127,7 +133,9 @@ jobs:
       - name: Try to Test Project
         id: failed-step
         continue-on-error: true
-        run: ctest --test-dir ${{ steps.cmake-action.outputs.build-dir }} --output-on-failure --no-tests=error -R hello_world
+        uses: threeal/ctest-action@v1.0.0
+        with:
+          tests-regex: hello_world
 
       - name: Previous Step Should Failed
         if: steps.failed-step.outcome == 'success'


### PR DESCRIPTION
This pull request resolves #261 by using the [CTest Action](https://github.com/marketplace/actions/ctest-action) as a replacement for the `ctest` command to run tests for this project in the GitHub Actions workflows. It also adds steps in other jobs for testing projects.