### PR TITLE
Add CMake Execution Functions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27726,6 +27726,14 @@ async function configureProject(inputs) {
     configureArgs.push(...inputs.args);
     await (0,exec.exec)("cmake", configureArgs);
 }
+/**
+ * Build a CMake project.
+ *
+ * @param inputs - The action inputs.
+ */
+async function buildProject(inputs) {
+    await (0,exec.exec)("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
+}
 
 ;// CONCATENATED MODULE: ./src/inputs.ts
 
@@ -27749,13 +27757,12 @@ function getInputs() {
 
 
 
-
 async function main() {
     const inputs = getInputs();
     await configureProject(inputs);
     core.setOutput("build-dir", inputs.buildDir);
     if (inputs.runBuild) {
-        await (0,exec.exec)("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
+        await buildProject(inputs);
     }
 }
 main().catch((err) => core.setFailed(err));

--- a/dist/index.js
+++ b/dist/index.js
@@ -27698,6 +27698,35 @@ var __webpack_exports__ = {};
 var core = __nccwpck_require__(2340);
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-exec-npm-1.1.1-90973d2f96-10c0.zip/node_modules/@actions/exec/lib/exec.js
 var exec = __nccwpck_require__(4926);
+;// CONCATENATED MODULE: ./src/cmake.ts
+
+/**
+ * Configures the build system of a CMake project.
+ *
+ * @param inputs - The action inputs.
+ */
+async function configureProject(inputs) {
+    const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
+    if (inputs.generator) {
+        configureArgs.push(...["-G", inputs.generator]);
+    }
+    if (inputs.cCompiler) {
+        configureArgs.push("-DCMAKE_C_COMPILER=" + inputs.cCompiler);
+    }
+    if (inputs.cxxCompiler) {
+        configureArgs.push("-DCMAKE_CXX_COMPILER=" + inputs.cxxCompiler);
+    }
+    if (inputs.cFlags) {
+        configureArgs.push("-DCMAKE_C_FLAGS=" + inputs.cFlags);
+    }
+    if (inputs.cxxFlags) {
+        configureArgs.push("-DCMAKE_CXX_FLAGS=" + inputs.cxxFlags);
+    }
+    configureArgs.push(...inputs.options.map((opt) => "-D" + opt));
+    configureArgs.push(...inputs.args);
+    await (0,exec.exec)("cmake", configureArgs);
+}
+
 ;// CONCATENATED MODULE: ./src/inputs.ts
 
 function getInputs() {
@@ -27720,27 +27749,10 @@ function getInputs() {
 
 
 
+
 async function main() {
     const inputs = getInputs();
-    const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
-    if (inputs.generator) {
-        configureArgs.push(...["-G", inputs.generator]);
-    }
-    if (inputs.cCompiler) {
-        configureArgs.push("-DCMAKE_C_COMPILER=" + inputs.cCompiler);
-    }
-    if (inputs.cxxCompiler) {
-        configureArgs.push("-DCMAKE_CXX_COMPILER=" + inputs.cxxCompiler);
-    }
-    if (inputs.cFlags) {
-        configureArgs.push("-DCMAKE_C_FLAGS=" + inputs.cFlags);
-    }
-    if (inputs.cxxFlags) {
-        configureArgs.push("-DCMAKE_CXX_FLAGS=" + inputs.cxxFlags);
-    }
-    configureArgs.push(...inputs.options.map((opt) => "-D" + opt));
-    configureArgs.push(...inputs.args);
-    await (0,exec.exec)("cmake", configureArgs);
+    await configureProject(inputs);
     core.setOutput("build-dir", inputs.buildDir);
     if (inputs.runBuild) {
         await (0,exec.exec)("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);

--- a/src/cmake.test.ts
+++ b/src/cmake.test.ts
@@ -1,0 +1,163 @@
+import { jest } from "@jest/globals";
+import type { Inputs } from "./inputs.js";
+
+jest.unstable_mockModule("@actions/exec", () => ({
+  exec: jest.fn(),
+}));
+
+describe("configure a CMake project", () => {
+  const defaultInputs: Inputs = {
+    sourceDir: ".",
+    buildDir: "build",
+    generator: "",
+    cCompiler: "",
+    cxxCompiler: "",
+    cFlags: "",
+    cxxFlags: "",
+    options: [],
+    args: [],
+    runBuild: true,
+    buildArgs: [],
+  };
+
+  interface TestCase {
+    name: string;
+    inputs: Inputs;
+    expectedArgs: string[];
+  }
+
+  const testCases: TestCase[] = [
+    {
+      name: "with nothing specified",
+      inputs: defaultInputs,
+      expectedArgs: [".", "-B", "build"],
+    },
+    {
+      name: "with source directory specified",
+      inputs: {
+        ...defaultInputs,
+        sourceDir: "project",
+      },
+      expectedArgs: ["project", "-B", "build"],
+    },
+    {
+      name: "with build directory specified",
+      inputs: {
+        ...defaultInputs,
+        buildDir: "output",
+      },
+      expectedArgs: [".", "-B", "output"],
+    },
+    {
+      name: "with generator specified",
+      inputs: {
+        ...defaultInputs,
+        generator: "Ninja",
+      },
+      expectedArgs: [".", "-B", "build", "-G", "Ninja"],
+    },
+    {
+      name: "with C compiler specified",
+      inputs: {
+        ...defaultInputs,
+        cCompiler: "clang",
+      },
+      expectedArgs: [".", "-B", "build", "-DCMAKE_C_COMPILER=clang"],
+    },
+    {
+      name: "with C++ compiler specified",
+      inputs: {
+        ...defaultInputs,
+        cxxCompiler: "clang++",
+      },
+      expectedArgs: [".", "-B", "build", "-DCMAKE_CXX_COMPILER=clang++"],
+    },
+    {
+      name: "with C flags specified",
+      inputs: {
+        ...defaultInputs,
+        cFlags: "-Werror -Wall",
+      },
+      expectedArgs: [".", "-B", "build", "-DCMAKE_C_FLAGS=-Werror -Wall"],
+    },
+    {
+      name: "with C++ flags specified",
+      inputs: {
+        ...defaultInputs,
+        cxxFlags: "-Werror -Wall -Wextra",
+      },
+      expectedArgs: [
+        ".",
+        "-B",
+        "build",
+        "-DCMAKE_CXX_FLAGS=-Werror -Wall -Wextra",
+      ],
+    },
+    {
+      name: "with additional options specified",
+      inputs: {
+        ...defaultInputs,
+        options: ["BUILD_TESTING=ON", "BUILD_EXAMPLES=ON"],
+      },
+      expectedArgs: [
+        ".",
+        "-B",
+        "build",
+        "-DBUILD_TESTING=ON",
+        "-DBUILD_EXAMPLES=ON",
+      ],
+    },
+    {
+      name: "with additional arguments specified",
+      inputs: {
+        ...defaultInputs,
+        args: ["-Wdev", "-Wdeprecated"],
+      },
+      expectedArgs: [".", "-B", "build", "-Wdev", "-Wdeprecated"],
+    },
+    {
+      name: "with all specified",
+      inputs: {
+        ...defaultInputs,
+        sourceDir: "project",
+        buildDir: "output",
+        generator: "Ninja",
+        cCompiler: "clang",
+        cxxCompiler: "clang++",
+        cFlags: "-Werror -Wall",
+        cxxFlags: "-Werror -Wall -Wextra",
+        options: ["BUILD_TESTING=ON", "BUILD_EXAMPLES=ON"],
+        args: ["-Wdev", "-Wdeprecated"],
+      },
+      expectedArgs: [
+        "project",
+        "-B",
+        "output",
+        "-G",
+        "Ninja",
+        "-DCMAKE_C_COMPILER=clang",
+        "-DCMAKE_CXX_COMPILER=clang++",
+        "-DCMAKE_C_FLAGS=-Werror -Wall",
+        "-DCMAKE_CXX_FLAGS=-Werror -Wall -Wextra",
+        "-DBUILD_TESTING=ON",
+        "-DBUILD_EXAMPLES=ON",
+        "-Wdev",
+        "-Wdeprecated",
+      ],
+    },
+  ];
+
+  for (const { name, inputs, expectedArgs } of testCases) {
+    it(`should execute the correct command ${name}`, async () => {
+      const { configureProject } = await import("./cmake.js");
+      const { exec } = await import("@actions/exec");
+
+      jest.mocked(exec).mockReset();
+
+      await expect(configureProject(inputs)).resolves.toBeUndefined();
+
+      expect(exec).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenLastCalledWith("cmake", expectedArgs);
+    });
+  }
+});

--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -34,3 +34,12 @@ export async function configureProject(inputs: Inputs): Promise<void> {
 
   await exec("cmake", configureArgs);
 }
+
+/**
+ * Build a CMake project.
+ *
+ * @param inputs - The action inputs.
+ */
+export async function buildProject(inputs: Inputs): Promise<void> {
+  await exec("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
+}

--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -1,0 +1,36 @@
+import { exec } from "@actions/exec";
+import type { Inputs } from "./inputs.js";
+
+/**
+ * Configures the build system of a CMake project.
+ *
+ * @param inputs - The action inputs.
+ */
+export async function configureProject(inputs: Inputs): Promise<void> {
+  const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
+
+  if (inputs.generator) {
+    configureArgs.push(...["-G", inputs.generator]);
+  }
+
+  if (inputs.cCompiler) {
+    configureArgs.push("-DCMAKE_C_COMPILER=" + inputs.cCompiler);
+  }
+
+  if (inputs.cxxCompiler) {
+    configureArgs.push("-DCMAKE_CXX_COMPILER=" + inputs.cxxCompiler);
+  }
+
+  if (inputs.cFlags) {
+    configureArgs.push("-DCMAKE_C_FLAGS=" + inputs.cFlags);
+  }
+
+  if (inputs.cxxFlags) {
+    configureArgs.push("-DCMAKE_CXX_FLAGS=" + inputs.cxxFlags);
+  }
+
+  configureArgs.push(...inputs.options.map((opt) => "-D" + opt));
+  configureArgs.push(...inputs.args);
+
+  await exec("cmake", configureArgs);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,13 @@
 import * as core from "@actions/core";
 import { exec } from "@actions/exec";
+import { configureProject } from "./cmake.js";
 import { getInputs } from "./inputs.js";
 
 async function main() {
   const inputs = getInputs();
 
-  const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
+  await configureProject(inputs);
 
-  if (inputs.generator) {
-    configureArgs.push(...["-G", inputs.generator]);
-  }
-
-  if (inputs.cCompiler) {
-    configureArgs.push("-DCMAKE_C_COMPILER=" + inputs.cCompiler);
-  }
-
-  if (inputs.cxxCompiler) {
-    configureArgs.push("-DCMAKE_CXX_COMPILER=" + inputs.cxxCompiler);
-  }
-
-  if (inputs.cFlags) {
-    configureArgs.push("-DCMAKE_C_FLAGS=" + inputs.cFlags);
-  }
-
-  if (inputs.cxxFlags) {
-    configureArgs.push("-DCMAKE_CXX_FLAGS=" + inputs.cxxFlags);
-  }
-
-  configureArgs.push(...inputs.options.map((opt) => "-D" + opt));
-  configureArgs.push(...inputs.args);
-
-  await exec("cmake", configureArgs);
   core.setOutput("build-dir", inputs.buildDir);
 
   if (inputs.runBuild) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as core from "@actions/core";
-import { exec } from "@actions/exec";
-import { configureProject } from "./cmake.js";
+import { buildProject, configureProject } from "./cmake.js";
 import { getInputs } from "./inputs.js";
 
 async function main() {
@@ -11,7 +10,7 @@ async function main() {
   core.setOutput("build-dir", inputs.buildDir);
 
   if (inputs.runBuild) {
-    await exec("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
+    await buildProject(inputs);
   }
 }
 


### PR DESCRIPTION
This pull request resolves #141 by adding CMake execution functions with their corresponding testing from lines in the `main` function.