### PR TITLE
Specify Action Inputs Testing One by One

### DIFF
--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -21,6 +21,65 @@ describe("get action inputs", () => {
       name: "with nothing specified",
     },
     {
+      name: "with source directory specified",
+      stringInputs: { "source-dir": "project" },
+      expectedInputs: { sourceDir: "project" },
+    },
+    {
+      name: "with build directory specified",
+      stringInputs: { "build-dir": "output" },
+      expectedInputs: { buildDir: "output" },
+    },
+    {
+      name: "with generator specified",
+      stringInputs: { generator: "Ninja" },
+      expectedInputs: { generator: "Ninja" },
+    },
+    {
+      name: "with C compiler specified",
+      stringInputs: { "c-compiler": "clang" },
+      expectedInputs: { cCompiler: "clang" },
+    },
+    {
+      name: "with C++ compiler specified",
+      stringInputs: { "cxx-compiler": "clang++" },
+      expectedInputs: { cxxCompiler: "clang++" },
+    },
+    {
+      name: "with C flags specified",
+      multilineInputs: { "c-flags": ["-Werror -Wall", "-Wextra"] },
+      expectedInputs: { cFlags: "-Werror -Wall -Wextra" },
+    },
+    {
+      name: "with C++ flags specified",
+      multilineInputs: { "cxx-flags": ["-Werror -Wall", "-Wextra -Wpedantic"] },
+      expectedInputs: { cxxFlags: "-Werror -Wall -Wextra -Wpedantic" },
+    },
+    {
+      name: "with additional options specified",
+      multilineInputs: {
+        options: ["BUILD_TESTING=ON BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
+      },
+      expectedInputs: {
+        options: ["BUILD_TESTING=ON", "BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
+      },
+    },
+    {
+      name: "with additional arguments specified",
+      multilineInputs: { args: ["-Wdev -Wdeprecated", "--fresh"] },
+      expectedInputs: { args: ["-Wdev", "-Wdeprecated", "--fresh"] },
+    },
+    {
+      name: "with run build specified",
+      booleanInputs: { "run-build": false },
+      expectedInputs: { runBuild: false },
+    },
+    {
+      name: "with additional build arguments specified",
+      multilineInputs: { "build-args": ["--target foo", "--parallel 8"] },
+      expectedInputs: { buildArgs: ["--target", "foo", "--parallel", "8"] },
+    },
+    {
       name: "with all specified",
       booleanInputs: {
         "run-build": false,

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -8,88 +8,87 @@ jest.unstable_mockModule("@actions/core", () => ({
 }));
 
 describe("get action inputs", () => {
-  const defaultInputs: Inputs = {
-    sourceDir: ".",
-    buildDir: "build",
-    generator: "",
-    cCompiler: "",
-    cxxCompiler: "",
-    cFlags: "",
-    cxxFlags: "",
-    options: [],
-    args: [],
-    runBuild: true,
-    buildArgs: [],
-  };
+  interface TestCase {
+    name: string;
+    booleanInputs?: { [key: string]: boolean };
+    stringInputs?: { [key: string]: string };
+    multilineInputs?: { [key: string]: string[] };
+    expectedInputs?: Partial<Inputs>;
+  }
 
-  let booleanInputs: { [key: string]: boolean };
-  let stringInputs: { [key: string]: string };
-  let multilineInputs: { [key: string]: string[] };
+  const testCases: TestCase[] = [
+    {
+      name: "with nothing specified",
+    },
+    {
+      name: "with all specified",
+      booleanInputs: {
+        "run-build": false,
+      },
+      stringInputs: {
+        "source-dir": "project",
+        "build-dir": "output",
+        generator: "Ninja",
+        "c-compiler": "clang",
+        "cxx-compiler": "clang++",
+      },
+      multilineInputs: {
+        "c-flags": ["-Werror -Wall", "-Wextra"],
+        "cxx-flags": ["-Werror -Wall", "-Wextra -Wpedantic"],
+        options: ["BUILD_TESTING=ON BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
+        args: ["-Wdev -Wdeprecated", "--fresh"],
+        "build-args": ["--target foo", "--parallel 8"],
+      },
+      expectedInputs: {
+        sourceDir: "project",
+        buildDir: "output",
+        generator: "Ninja",
+        cCompiler: "clang",
+        cxxCompiler: "clang++",
+        cFlags: "-Werror -Wall -Wextra",
+        cxxFlags: "-Werror -Wall -Wextra -Wpedantic",
+        options: ["BUILD_TESTING=ON", "BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
+        args: ["-Wdev", "-Wdeprecated", "--fresh"],
+        runBuild: false,
+        buildArgs: ["--target", "foo", "--parallel", "8"],
+      },
+    },
+  ];
 
-  beforeEach(async () => {
-    const core = await import("@actions/core");
+  for (const testCase of testCases) {
+    it(`should get the action inputs ${testCase.name}`, async () => {
+      const { getInputs } = await import("./inputs.js");
+      const core = await import("@actions/core");
 
-    booleanInputs = { "run-build": true };
-    stringInputs = {};
-    multilineInputs = {};
+      const booleanInputs = { "run-build": true, ...testCase.booleanInputs };
+      jest.mocked(core.getBooleanInput).mockImplementation((name) => {
+        return booleanInputs[name] ?? false;
+      });
 
-    jest.mocked(core.getBooleanInput).mockImplementation((name) => {
-      return booleanInputs[name] ?? false;
+      const stringInputs = { ...testCase.stringInputs };
+      jest.mocked(core.getInput).mockImplementation((name) => {
+        return stringInputs[name] ?? "";
+      });
+
+      const multilineInputs = { ...testCase.multilineInputs };
+      jest.mocked(core.getMultilineInput).mockImplementation((name) => {
+        return multilineInputs[name] ?? [];
+      });
+
+      expect(getInputs()).toStrictEqual({
+        sourceDir: ".",
+        buildDir: "build",
+        generator: "",
+        cCompiler: "",
+        cxxCompiler: "",
+        cFlags: "",
+        cxxFlags: "",
+        options: [],
+        args: [],
+        runBuild: true,
+        buildArgs: [],
+        ...testCase.expectedInputs,
+      });
     });
-
-    jest.mocked(core.getInput).mockImplementation((name) => {
-      return stringInputs[name] ?? "";
-    });
-
-    jest.mocked(core.getMultilineInput).mockImplementation((name) => {
-      return multilineInputs[name] ?? [];
-    });
-  });
-
-  it("should get the action inputs with nothing specified", async () => {
-    const { getInputs } = await import("./inputs.js");
-
-    expect(getInputs()).toStrictEqual(defaultInputs);
-  });
-
-  it("should get the action inputs with all specified", async () => {
-    const { getInputs } = await import("./inputs.js");
-
-    booleanInputs = {
-      ...booleanInputs,
-      "run-build": false,
-    };
-
-    stringInputs = {
-      ...stringInputs,
-      "source-dir": "project",
-      "build-dir": "output",
-      generator: "Ninja",
-      "c-compiler": "clang",
-      "cxx-compiler": "clang++",
-    };
-
-    multilineInputs = {
-      ...multilineInputs,
-      "c-flags": ["-Werror -Wall", "-Wextra"],
-      "cxx-flags": ["-Werror -Wall", "-Wextra -Wpedantic"],
-      options: ["BUILD_TESTING=ON BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
-      args: ["-Wdev -Wdeprecated", "--fresh"],
-      "build-args": ["--target foo", "--parallel 8"],
-    };
-
-    expect(getInputs()).toStrictEqual({
-      sourceDir: "project",
-      buildDir: "output",
-      generator: "Ninja",
-      cCompiler: "clang",
-      cxxCompiler: "clang++",
-      cFlags: "-Werror -Wall -Wextra",
-      cxxFlags: "-Werror -Wall -Wextra -Wpedantic",
-      options: ["BUILD_TESTING=ON", "BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
-      args: ["-Wdev", "-Wdeprecated", "--fresh"],
-      runBuild: false,
-      buildArgs: ["--target", "foo", "--parallel", "8"],
-    });
-  });
+  }
 });

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -22,15 +22,28 @@ describe("get action inputs", () => {
     buildArgs: [],
   };
 
+  let booleanInputs: { [key: string]: boolean };
+  let stringInputs: { [key: string]: string };
+  let multilineInputs: { [key: string]: string[] };
+
   beforeEach(async () => {
     const core = await import("@actions/core");
 
+    booleanInputs = { "run-build": true };
+    stringInputs = {};
+    multilineInputs = {};
+
     jest.mocked(core.getBooleanInput).mockImplementation((name) => {
-      return name == "run-build";
+      return booleanInputs[name] ?? false;
     });
 
-    jest.mocked(core.getInput).mockReturnValue("");
-    jest.mocked(core.getMultilineInput).mockReturnValue([]);
+    jest.mocked(core.getInput).mockImplementation((name) => {
+      return stringInputs[name] ?? "";
+    });
+
+    jest.mocked(core.getMultilineInput).mockImplementation((name) => {
+      return multilineInputs[name] ?? [];
+    });
   });
 
   it("should get the action inputs with nothing specified", async () => {
@@ -41,41 +54,29 @@ describe("get action inputs", () => {
 
   it("should get the action inputs with all specified", async () => {
     const { getInputs } = await import("./inputs.js");
-    const core = await import("@actions/core");
 
-    jest.mocked(core.getBooleanInput).mockReturnValue(false);
+    booleanInputs = {
+      ...booleanInputs,
+      "run-build": false,
+    };
 
-    jest.mocked(core.getInput).mockImplementation((name) => {
-      switch (name) {
-        case "source-dir":
-          return "project";
-        case "build-dir":
-          return "output";
-        case "generator":
-          return "Ninja";
-        case "c-compiler":
-          return "clang";
-        case "cxx-compiler":
-          return "clang++";
-      }
-      return "";
-    });
+    stringInputs = {
+      ...stringInputs,
+      "source-dir": "project",
+      "build-dir": "output",
+      generator: "Ninja",
+      "c-compiler": "clang",
+      "cxx-compiler": "clang++",
+    };
 
-    jest.mocked(core.getMultilineInput).mockImplementation((name) => {
-      switch (name) {
-        case "c-flags":
-          return ["-Werror -Wall", "-Wextra"];
-        case "cxx-flags":
-          return ["-Werror -Wall", "-Wextra -Wpedantic"];
-        case "options":
-          return ["BUILD_TESTING=ON BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"];
-        case "args":
-          return ["-Wdev -Wdeprecated", "--fresh"];
-        case "build-args":
-          return ["--target foo", "--parallel 8"];
-      }
-      return [];
-    });
+    multilineInputs = {
+      ...multilineInputs,
+      "c-flags": ["-Werror -Wall", "-Wextra"],
+      "cxx-flags": ["-Werror -Wall", "-Wextra -Wpedantic"],
+      options: ["BUILD_TESTING=ON BUILD_EXAMPLES=ON", "BUILD_DOCS=ON"],
+      args: ["-Wdev -Wdeprecated", "--fresh"],
+      "build-args": ["--target foo", "--parallel 8"],
+    };
 
     expect(getInputs()).toStrictEqual({
       sourceDir: "project",


### PR DESCRIPTION
This pull request resolves #267 by refactoring the get Action inputs testing in the `inputs.test.ts` file. The change encompass simplifying testing by using test cases and add more testing that cover specifying inputs one by one.