### PR TITLE
Fix Default Build Directory not Relative to Source Directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,6 @@ jobs:
         run: mv test/* .
 
       - name: Configure and Build Project
-        id: cmake-action
         uses: ./
 
       - name: Test Project
@@ -135,6 +134,7 @@ jobs:
         continue-on-error: true
         uses: threeal/ctest-action@v1.0.0
         with:
+          test-dir: ${{ steps.cmake-action.outputs.build-dir }}
           tests-regex: hello_world
 
       - name: Previous Step Should Failed
@@ -159,6 +159,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Configure and Build Project
+        id: cmake-action
         uses: ./
         with:
           source-dir: test
@@ -170,6 +171,7 @@ jobs:
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0
         with:
+          test-dir: ${{ steps.cmake-action.outputs.build-dir }}
           build-config: Debug
           tests-regex: test
 
@@ -194,6 +196,7 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@v4
 
       - name: Configure and Build Project
+        id: cmake-action
         uses: ./
         with:
           source-dir: test
@@ -206,4 +209,5 @@ jobs:
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0
         with:
+          test-dir: ${{ steps.cmake-action.outputs.build-dir }}
           tests-regex: test

--- a/dist/index.js
+++ b/dist/index.js
@@ -27685,6 +27685,35 @@ module.exports = parseParams
 /******/ }
 /******/ 
 /************************************************************************/
+/******/ /* webpack/runtime/compat get default export */
+/******/ (() => {
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__nccwpck_require__.n = (module) => {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			() => (module['default']) :
+/******/ 			() => (module);
+/******/ 		__nccwpck_require__.d(getter, { a: getter });
+/******/ 		return getter;
+/******/ 	};
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ (() => {
+/******/ 	// define getter functions for harmony exports
+/******/ 	__nccwpck_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ (() => {
+/******/ 	__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ })();
+/******/ 
 /******/ /* webpack/runtime/compat */
 /******/ 
 /******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
@@ -27735,12 +27764,17 @@ async function buildProject(inputs) {
     await (0,exec.exec)("cmake", ["--build", inputs.buildDir, ...inputs.buildArgs]);
 }
 
+;// CONCATENATED MODULE: external "node:path"
+const external_node_path_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:path");
+var external_node_path_default = /*#__PURE__*/__nccwpck_require__.n(external_node_path_namespaceObject);
 ;// CONCATENATED MODULE: ./src/inputs.ts
 
+
 function getInputs() {
+    const sourceDir = (0,core.getInput)("source-dir") || ".";
     return {
-        sourceDir: (0,core.getInput)("source-dir") || ".",
-        buildDir: (0,core.getInput)("build-dir") || "build",
+        sourceDir,
+        buildDir: (0,core.getInput)("build-dir") || external_node_path_default().join(sourceDir, "build"),
         generator: (0,core.getInput)("generator"),
         cCompiler: (0,core.getInput)("c-compiler"),
         cxxCompiler: (0,core.getInput)("cxx-compiler"),

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import path from "node:path";
 import type { Inputs } from "./inputs.js";
 
 jest.unstable_mockModule("@actions/core", () => ({
@@ -23,12 +24,26 @@ describe("get action inputs", () => {
     {
       name: "with source directory specified",
       stringInputs: { "source-dir": "project" },
-      expectedInputs: { sourceDir: "project" },
+      expectedInputs: {
+        sourceDir: "project",
+        buildDir: path.join("project", "build"),
+      },
     },
     {
       name: "with build directory specified",
       stringInputs: { "build-dir": "output" },
       expectedInputs: { buildDir: "output" },
+    },
+    {
+      name: "with source and build directories specified",
+      stringInputs: {
+        "source-dir": "project",
+        "build-dir": "output",
+      },
+      expectedInputs: {
+        sourceDir: "project",
+        buildDir: "output",
+      },
     },
     {
       name: "with generator specified",

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,4 +1,5 @@
 import { getBooleanInput, getInput, getMultilineInput } from "@actions/core";
+import path from "node:path";
 
 export interface Inputs {
   sourceDir: string;
@@ -15,9 +16,10 @@ export interface Inputs {
 }
 
 export function getInputs(): Inputs {
+  const sourceDir = getInput("source-dir") || ".";
   return {
-    sourceDir: getInput("source-dir") || ".",
-    buildDir: getInput("build-dir") || "build",
+    sourceDir,
+    buildDir: getInput("build-dir") || path.join(sourceDir, "build"),
     generator: getInput("generator"),
     cCompiler: getInput("c-compiler"),
     cxxCompiler: getInput("cxx-compiler"),


### PR DESCRIPTION
This pull request resolves #266 by fixing the default build directory to be relative to the source directory. It also adds a new unit test to verify this behavior and fix the location of the test directory in the CI workflows.