### PR TITLE
Remove Redundant Specification of CMake Source Directory

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27771,7 +27771,7 @@ var external_node_path_default = /*#__PURE__*/__nccwpck_require__.n(external_nod
 
 
 function getInputs() {
-    const sourceDir = (0,core.getInput)("source-dir") || ".";
+    const sourceDir = (0,core.getInput)("source-dir");
     return {
         sourceDir,
         buildDir: (0,core.getInput)("build-dir") || external_node_path_default().join(sourceDir, "build"),

--- a/dist/index.js
+++ b/dist/index.js
@@ -27735,7 +27735,11 @@ var exec = __nccwpck_require__(4926);
  * @param inputs - The action inputs.
  */
 async function configureProject(inputs) {
-    const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
+    const configureArgs = [];
+    if (inputs.sourceDir) {
+        configureArgs.push(inputs.sourceDir);
+    }
+    configureArgs.push("-B", inputs.buildDir);
     if (inputs.generator) {
         configureArgs.push(...["-G", inputs.generator]);
     }

--- a/src/cmake.test.ts
+++ b/src/cmake.test.ts
@@ -8,7 +8,7 @@ interface TestCase {
 }
 
 const defaultInputs: Inputs = {
-  sourceDir: ".",
+  sourceDir: "",
   buildDir: "build",
   generator: "",
   cCompiler: "",
@@ -29,7 +29,7 @@ describe("configure a CMake project", () => {
   const testCases: TestCase[] = [
     {
       name: "with nothing specified",
-      expectedArgs: [".", "-B", "build"],
+      expectedArgs: ["-B", "build"],
     },
     {
       name: "with source directory specified",
@@ -39,43 +39,37 @@ describe("configure a CMake project", () => {
     {
       name: "with build directory specified",
       inputs: { buildDir: "output" },
-      expectedArgs: [".", "-B", "output"],
+      expectedArgs: ["-B", "output"],
     },
     {
       name: "with generator specified",
       inputs: { generator: "Ninja" },
-      expectedArgs: [".", "-B", "build", "-G", "Ninja"],
+      expectedArgs: ["-B", "build", "-G", "Ninja"],
     },
     {
       name: "with C compiler specified",
       inputs: { cCompiler: "clang" },
-      expectedArgs: [".", "-B", "build", "-DCMAKE_C_COMPILER=clang"],
+      expectedArgs: ["-B", "build", "-DCMAKE_C_COMPILER=clang"],
     },
     {
       name: "with C++ compiler specified",
       inputs: { cxxCompiler: "clang++" },
-      expectedArgs: [".", "-B", "build", "-DCMAKE_CXX_COMPILER=clang++"],
+      expectedArgs: ["-B", "build", "-DCMAKE_CXX_COMPILER=clang++"],
     },
     {
       name: "with C flags specified",
       inputs: { cFlags: "-Werror -Wall" },
-      expectedArgs: [".", "-B", "build", "-DCMAKE_C_FLAGS=-Werror -Wall"],
+      expectedArgs: ["-B", "build", "-DCMAKE_C_FLAGS=-Werror -Wall"],
     },
     {
       name: "with C++ flags specified",
       inputs: { cxxFlags: "-Werror -Wall -Wextra" },
-      expectedArgs: [
-        ".",
-        "-B",
-        "build",
-        "-DCMAKE_CXX_FLAGS=-Werror -Wall -Wextra",
-      ],
+      expectedArgs: ["-B", "build", "-DCMAKE_CXX_FLAGS=-Werror -Wall -Wextra"],
     },
     {
       name: "with additional options specified",
       inputs: { options: ["BUILD_TESTING=ON", "BUILD_EXAMPLES=ON"] },
       expectedArgs: [
-        ".",
         "-B",
         "build",
         "-DBUILD_TESTING=ON",
@@ -85,7 +79,7 @@ describe("configure a CMake project", () => {
     {
       name: "with additional arguments specified",
       inputs: { args: ["-Wdev", "-Wdeprecated"] },
-      expectedArgs: [".", "-B", "build", "-Wdev", "-Wdeprecated"],
+      expectedArgs: ["-B", "build", "-Wdev", "-Wdeprecated"],
     },
     {
       name: "with all specified",

--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -7,7 +7,13 @@ import type { Inputs } from "./inputs.js";
  * @param inputs - The action inputs.
  */
 export async function configureProject(inputs: Inputs): Promise<void> {
-  const configureArgs = [inputs.sourceDir, "-B", inputs.buildDir];
+  const configureArgs = [];
+
+  if (inputs.sourceDir) {
+    configureArgs.push(inputs.sourceDir);
+  }
+
+  configureArgs.push("-B", inputs.buildDir);
 
   if (inputs.generator) {
     configureArgs.push(...["-G", inputs.generator]);

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -150,7 +150,7 @@ describe("get action inputs", () => {
       });
 
       expect(getInputs()).toStrictEqual({
-        sourceDir: ".",
+        sourceDir: "",
         buildDir: "build",
         generator: "",
         cCompiler: "",

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -16,7 +16,7 @@ export interface Inputs {
 }
 
 export function getInputs(): Inputs {
-  const sourceDir = getInput("source-dir") || ".";
+  const sourceDir = getInput("source-dir");
   return {
     sourceDir,
     buildDir: getInput("build-dir") || path.join(sourceDir, "build"),


### PR DESCRIPTION
This pull request resolves #270 by introducing the following changes:
- Remove the setting of the default value for the `source-dir` input to `.`.
- Append the source directory to the CMake configuration arguments only if it is specified.