### PR TITLE
Run ESLint with No File Arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "ncc build src/index.ts",
     "format": "prettier --write --cache . !dist !README.md",
-    "lint": "eslint .",
+    "lint": "eslint",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request simply resolves #295  by modifying the `lint` script in the `package.json` file to run the `eslint` command with no file arguments.