### PR TITLE
Separate Check Package Job into Check Workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,31 @@
+name: Check
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  check-package:
+    name: Check Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: latest
+
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v2.0.0
+        with:
+          version: stable
+
+      - name: Check Format
+        run: |
+          yarn format
+          git diff --exit-code HEAD
+
+      - name: Check Lint
+        run: yarn lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,31 +5,6 @@ on:
   push:
     branches: [main]
 jobs:
-  check-package:
-    name: Check Package
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4.0.2
-        with:
-          node-version: latest
-
-      - name: Setup Yarn
-        uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
-
-      - name: Check Format
-        run: |
-          yarn format
-          git diff --exit-code HEAD
-
-      - name: Check Lint
-        run: yarn lint
-
   test-package:
     name: Test Package
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request resolves #329 by simply separating the `check-package` job in the `test` workflow into a new `check` workflow.