### PR TITLE
Specify External Project Version to Use in Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.7
@@ -62,6 +63,7 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
           path: project
 
       - name: Checkout Action
@@ -91,6 +93,7 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.7
@@ -117,6 +120,7 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.7
@@ -143,6 +147,7 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #368 by specifying the version of the external project to be used in this workflow. This change specifies the [C++ Starter](https://github.com/threeal/cpp-starter/) project to use version [1.0.0](https://github.com/threeal/cpp-starter/releases/tag/v1.0.0).