### PR TITLE
Specify TypeScript Source Files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "module": "node16",
     "moduleResolution": "node16",


### PR DESCRIPTION
This pull request resolves #388 by including only the source files inside the `src` directory and excluding test files from being compiled by TypeScript.