### PR TITLE
Enable TypeScript Strict Configuration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26698,6 +26698,10 @@ var __webpack_exports__ = {};
 
 // EXTERNAL MODULE: ../../../.yarn/berry/cache/@actions-core-npm-1.10.1-3cb1000b4d-10c0.zip/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2340);
+;// CONCATENATED MODULE: ../../../.yarn/berry/cache/catched-error-message-npm-0.0.1-9126a73d25-10c0.zip/node_modules/catched-error-message/dist/index.esm.js
+function r(r){return function(r){if("object"==typeof(e=r)&&null!==e&&"message"in e&&"string"==typeof e.message)return r;var e;try{return new Error(JSON.stringify(r))}catch(e){return new Error(String(r))}}(r).message}
+//# sourceMappingURL=index.esm.js.map
+
 ;// CONCATENATED MODULE: external "node:child_process"
 const external_node_child_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:child_process");
 ;// CONCATENATED MODULE: ./src/cmake.ts
@@ -26770,6 +26774,7 @@ function getInputs() {
 
 
 
+
 try {
     const inputs = getInputs();
     configureProject(inputs);
@@ -26779,7 +26784,7 @@ try {
     }
 }
 catch (err) {
-    core.setFailed(err);
+    core.setFailed(r(err));
 }
 
 })();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@actions/core": "^1.10.1"
+    "@actions/core": "^1.10.1",
+    "catched-error-message": "^0.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import { getErrorMessage } from "catched-error-message";
 import { buildProject, configureProject } from "./cmake.js";
 import { getInputs } from "./inputs.js";
 
@@ -13,5 +14,5 @@ try {
     buildProject(inputs);
   }
 } catch (err) {
-  core.setFailed(err);
+  core.setFailed(getErrorMessage(err));
 }

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -134,7 +134,10 @@ describe("get action inputs", () => {
       const { getInputs } = await import("./inputs.js");
       const core = await import("@actions/core");
 
-      const booleanInputs = { "run-build": true, ...testCase.booleanInputs };
+      const booleanInputs: Record<string, boolean> = {
+        "run-build": true,
+        ...testCase.booleanInputs,
+      };
       jest.mocked(core.getBooleanInput).mockImplementation((name) => {
         return booleanInputs[name] ?? false;
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,6 +1521,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catched-error-message@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "catched-error-message@npm:0.0.1"
+  checksum: 10c0/1f10cd4323a73bec7a57b7495730e5dad9995120b04e85b5f654f7b40dc6a36320d95cc55e49cdf78753158e18790ef725e2ec7309ebced3acd6c9a557ac075b
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -3890,6 +3897,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^22.1.0"
     "@vercel/ncc": "npm:^0.38.1"
+    catched-error-message: "npm:^0.0.1"
     eslint: "npm:^9.8.0"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.3.3"


### PR DESCRIPTION
This pull request resolves #394 by introducing the following changes:
- Uses the [catched-error-message](https://www.npmjs.com/package/catched-error-message) package to stringify caught errors.
- Enables TypeScript strict configuration.
- Configures TypeScript to skip library checks.