### PR TITLE
Fix Build Diff Check in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
           version: stable
 
       - name: Build Package
-        run: |
-          yarn build
-          git diff --exit-code HEAD
+        run: yarn build
+
+      - name: Check Diff
+        run: git diff --exit-code HEAD

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,4 +26,4 @@ jobs:
         run: yarn build
 
       - name: Check Diff
-        run: git diff --exit-code HEAD
+        run: git diff && git diff-index --quiet --exit-code HEAD

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,7 +26,7 @@ jobs:
         run: yarn format
 
       - name: Check Diff
-        run: git diff --exit-code HEAD
+        run: git diff && git diff-index --quiet --exit-code HEAD
 
       - name: Check Lint
         run: yarn lint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,9 +23,10 @@ jobs:
           version: stable
 
       - name: Check Formatting
-        run: |
-          yarn format
-          git diff --exit-code HEAD
+        run: yarn format
+
+      - name: Check Diff
+        run: git diff --exit-code HEAD
 
       - name: Check Lint
         run: yarn lint


### PR DESCRIPTION
This pull request resolves #401 by separating the Git diff check into separate steps and modifying them to utilize the `git diff-index` command for asserting whether there are changes in the diff.