### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-package:
     name: Build Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-package:
     name: Check Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-package:
     name: Test Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7
@@ -25,11 +25,11 @@ jobs:
 
   test-action:
     name: Test Action
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows, ubuntu, macos]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - name: Checkout Sample Project
         uses: actions/checkout@v4.1.7
@@ -51,11 +51,11 @@ jobs:
         uses: ./cmake-action
 
       - name: Run Sample Project
-        run: ${{ steps.cmake-action.outputs.build-dir }}/${{ matrix.os == 'windows' && 'Debug/generate_sequence.exe' || 'generate_sequence' }} 5
+        run: ${{ steps.cmake-action.outputs.build-dir }}/${{ matrix.os == 'windows-2022' && 'Debug/generate_sequence.exe' || 'generate_sequence' }} 5
 
   test-action-with-specified-dirs:
     name: Test Action With Specified Directories
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Sample Project
         uses: actions/checkout@v4.1.7
@@ -85,7 +85,7 @@ jobs:
 
   test-action-without-run-build:
     name: Test Action Without Run Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Sample Project
         uses: actions/checkout@v4.1.7
@@ -112,7 +112,7 @@ jobs:
 
   test-action-with-additional-options:
     name: Test Action With Additional Options
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Sample Project
         uses: actions/checkout@v4.1.7
@@ -139,7 +139,7 @@ jobs:
 
   test-action-with-custom-generator:
     name: Test Action With Custom Generator
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Sample Project
         uses: actions/checkout@v4.1.7

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ on:
 jobs:
   build-project:
     name: Build Project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #444 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.