### PR TITLE
Extend TypeScript Configuration from Node.js Base Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@eslint/js": "^9.22.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
+    "@tsconfig/node23": "^23.0.0",
     "@types/node": "^22.13.10",
     "@vitest/coverage-v8": "^3.0.8",
     "eslint": "^9.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^12.1.2
         version: 12.1.2(rollup@4.36.0)(tslib@2.8.1)(typescript@5.8.2)
+      '@tsconfig/node23':
+        specifier: ^23.0.0
+        version: 23.0.0
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -451,6 +454,9 @@ packages:
     resolution: {integrity: sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==}
     cpu: [x64]
     os: [win32]
+
+  '@tsconfig/node23@23.0.0':
+    resolution: {integrity: sha512-a2qO9QOEWnomKbFFE3XlOJ5za6Sc+XduxQkFpah42enbTPFPaW0QzKw616KDNfmMLPhXMwCw4EHVjcKaFOj/OA==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1522,6 +1528,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.36.0':
     optional: true
+
+  '@tsconfig/node23@23.0.0': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,8 @@
 {
+  "extends": "@tsconfig/node23",
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
-    "strict": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2022",
-    "skipLibCheck": true
+    "module": "node16"
   }
 }


### PR DESCRIPTION
This pull request resolves #659 by extending `tsconfig.json` from [@tsconfig/node23](https://www.npmjs.com/package/@tsconfig/node23).