### PR TITLE
Move Built Dependencies Config to `pnpm-workspace.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,5 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1",
     "vitest": "^3.0.8"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
This pull request resolves #713 by moving the `onlyBuiltDependencies` config from the `package.json` file to the `pnpm-workspace.yaml` file.