### PR TITLE
Strict TypeScript ESLint configuration

### DIFF
--- a/dist/action.mjs
+++ b/dist/action.mjs
@@ -82,7 +82,7 @@ async function exec(command, args) {
                 resolve();
             }
             else {
-                reject(new Error(`Command exited with status code ${code}`));
+                reject(new Error(`Command exited with status code ${code.toString()}`));
             }
         });
     });
@@ -136,7 +136,7 @@ function parse(str) {
     const args = [];
     let match;
     while ((match = regex.exec(str)) !== null) {
-        args.push(match[1] ?? match[2] ?? match[3] ?? match[4]);
+        args.push(match[1] || match[2] || match[3] || match[4]);
     }
     return args;
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,20 @@
 import eslint from "@eslint/js";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default [
+export default tseslint.config(
+  globalIgnores(["dist"]),
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...tseslint.configs.stylistic,
-  { ignores: ["dist"] },
-];
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+          allowDefaultProject: ["rollup.config.js"],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^22.15.30",
     "@vitest/coverage-v8": "^3.1.4",
     "eslint": "^9.28.0",
+    "jiti": "^2.4.2",
     "lefthook": "^1.11.14",
     "prettier": "^3.5.3",
     "rollup": "^4.41.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,10 +29,13 @@ importers:
         version: 22.15.30
       '@vitest/coverage-v8':
         specifier: ^3.1.4
-        version: 3.1.4(vitest@3.1.4(@types/node@22.15.30))
+        version: 3.1.4(vitest@3.1.4(@types/node@22.15.30)(jiti@2.4.2))
       eslint:
         specifier: ^9.28.0
-        version: 9.28.0
+        version: 9.28.0(jiti@2.4.2)
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       lefthook:
         specifier: ^1.11.14
         version: 1.11.14
@@ -50,10 +53,10 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.33.1
-        version: 8.33.1(eslint@9.28.0)(typescript@5.8.3)
+        version: 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: ^3.1.4
-        version: 3.1.4(@types/node@22.15.30)
+        version: 3.1.4(@types/node@22.15.30)(jiti@2.4.2)
 
 packages:
 
@@ -900,6 +903,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1435,9 +1442,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.28.0
+      eslint: 9.28.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1634,15 +1641,15 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.33.1
-      '@typescript-eslint/type-utils': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.33.1
-      eslint: 9.28.0
+      eslint: 9.28.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1651,14 +1658,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.33.1
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.33.1
       debug: 4.4.1
-      eslint: 9.28.0
+      eslint: 9.28.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1681,12 +1688,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.33.1(eslint@9.28.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.28.0
+      eslint: 9.28.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1710,13 +1717,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.33.1(eslint@9.28.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.33.1
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.8.3)
-      eslint: 9.28.0
+      eslint: 9.28.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1726,7 +1733,7 @@ snapshots:
       '@typescript-eslint/types': 8.33.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.15.30))':
+  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.15.30)(jiti@2.4.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1740,7 +1747,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@types/node@22.15.30)
+      vitest: 3.1.4(@types/node@22.15.30)(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1751,13 +1758,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@6.2.0(@types/node@22.15.30))':
+  '@vitest/mocker@3.1.4(vite@6.2.0(@types/node@22.15.30)(jiti@2.4.2))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@22.15.30)
+      vite: 6.2.0(@types/node@22.15.30)(jiti@2.4.2)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -1916,9 +1923,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.28.0:
+  eslint@9.28.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0
       '@eslint/config-helpers': 0.2.2
@@ -1953,6 +1960,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2120,6 +2129,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jiti@2.4.2: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -2409,12 +2420,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.33.1(eslint@9.28.0)(typescript@5.8.3):
+  typescript-eslint@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0)(typescript@5.8.3))(eslint@9.28.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0)(typescript@5.8.3)
-      eslint: 9.28.0
+      '@typescript-eslint/eslint-plugin': 8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.28.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2427,13 +2438,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.1.4(@types/node@22.15.30):
+  vite-node@3.1.4(@types/node@22.15.30)(jiti@2.4.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@22.15.30)
+      vite: 6.2.0(@types/node@22.15.30)(jiti@2.4.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2448,7 +2459,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.0(@types/node@22.15.30):
+  vite@6.2.0(@types/node@22.15.30)(jiti@2.4.2):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -2456,11 +2467,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.30
       fsevents: 2.3.3
+      jiti: 2.4.2
 
-  vitest@3.1.4(@types/node@22.15.30):
+  vitest@3.1.4(@types/node@22.15.30)(jiti@2.4.2):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.2.0(@types/node@22.15.30))
+      '@vitest/mocker': 3.1.4(vite@6.2.0(@types/node@22.15.30)(jiti@2.4.2))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -2477,8 +2489,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@22.15.30)
-      vite-node: 3.1.4(@types/node@22.15.30)
+      vite: 6.2.0(@types/node@22.15.30)(jiti@2.4.2)
+      vite-node: 3.1.4(@types/node@22.15.30)(jiti@2.4.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.30

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -183,7 +183,7 @@ describe("get action context", () => {
       const { getInput } = await import("gha-utils");
       const { getContext } = await import("./context.js");
 
-      const inputs = testCase.inputs || {};
+      const inputs = testCase.inputs ?? {};
       vi.mocked(getInput).mockImplementation((name) => inputs[name] ?? "");
 
       expect(getContext()).toStrictEqual({

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -17,11 +17,11 @@ export async function exec(command: string, args: string[]): Promise<void> {
     });
     logCommand(proc.spawnfile, ...proc.spawnargs.splice(1));
     proc.on("error", reject);
-    proc.on("close", (code) => {
+    proc.on("close", (code: number) => {
       if (code === 0) {
         resolve();
       } else {
-        reject(new Error(`Command exited with status code ${code}`));
+        reject(new Error(`Command exited with status code ${code.toString()}`));
       }
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export function parse(str: string): string[] {
   const args: string[] = [];
   let match: RegExpExecArray | null;
   while ((match = regex.exec(str)) !== null) {
-    args.push(match[1] ?? match[2] ?? match[3] ?? match[4]);
+    args.push(match[1] || match[2] || match[3] || match[4]);
   }
   return args;
 }


### PR DESCRIPTION
This pull request resolves #743 by enabling a stricter TypeScript configuration. This change also convert the ESLint configuration to TypeScript.