### PR TITLE
Remove Setup Ninja Action in CI Workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,9 +138,6 @@ jobs:
             dist
           sparse-checkout-cone-mode: false
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
       - name: Configure Sample Project
         id: cmake-action
         uses: ./cmake-action

--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ By default, this action uses the current working directory as the source directo
 The following example demonstrates how to use this action to configure and build the project using [Ninja](https://ninja-build.org/) as the build system generator and [Clang](https://clang.llvm.org/) as the compiler:
 
 ```yaml
-- name: Setup Ninja
-  uses: seanmiddleditch/gha-setup-ninja@v5
-
 - name: Build Project
   uses: threeal/cmake-action@v2.1.0
   with:


### PR DESCRIPTION
This pull request resolves #754 by removing the `seanmiddleditch/gha-setup-ninja` action from the CI workflow and the `README.md` file.