### PR TITLE
Remove tslib From Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "lefthook": "^1.11.14",
     "prettier": "^3.6.2",
     "rollup": "^4.44.1",
-    "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.1",
     "vitest": "^3.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       rollup:
         specifier: ^4.44.1
         version: 4.44.1
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2450,7 +2447,8 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
This pull request resolves #773 by removing the unused tslib package from the dependencies in this project.