### PR TITLE
Remove Glob Pattern for Filtering Lefthook Jobs

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,10 +8,10 @@ pre-commit:
       run: pnpm tsc
 
     - name: fix formatting
-      run: pnpm prettier --write --ignore-unknown {staged_files}
+      run: pnpm prettier --write .
 
     - name: fix lint
-      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+      run: pnpm eslint --fix
 
     - name: build action
       run: pnpm rollup -c

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -17,4 +17,4 @@ pre-commit:
       run: pnpm rollup -c
 
     - name: check diff
-      run: git diff --exit-code dist {staged_files}
+      run: git diff --exit-code dist pnpm-lock.yaml {staged_files}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,18 +3,9 @@ pre-commit:
   jobs:
     - name: install dependencies
       run: pnpm install
-      glob:
-        - package.json
-        - pnpm-lock.yaml
-        - pnpm-workspace.yaml
 
     - name: check types
       run: pnpm tsc
-      glob:
-        - "*.ts"
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
 
     - name: fix formatting
       run: pnpm prettier --write --ignore-unknown {staged_files}
@@ -24,14 +15,6 @@ pre-commit:
 
     - name: build action
       run: pnpm rollup -c
-      glob:
-        - dist/*
-        - src/*.ts
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
-      exclude:
-        - src/*.test.ts
 
     - name: check diff
       run: git diff --exit-code dist {staged_files}


### PR DESCRIPTION
This pull request resolves #775 by removing the glob pattern used to filter Lefthook jobs. It also modifies jobs to process all files and adds the `pnpm-lock.yaml` file to the list of files checked for changes.