### PR TITLE
Lock pnpm to Version 10.33.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.42.0",
     "vitest": "^3.1.4"
-  }
+  },
+  "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
This pull request resolves #889 by locking the pnpm version used in this project to version 10.33.4 both in the GitHub Actions workflow and `package.json`.